### PR TITLE
fix: swapped bytes of CAN ID

### DIFF
--- a/main/slcan.c
+++ b/main/slcan.c
@@ -242,10 +242,10 @@ static uint8_t slcan_set_frame(uint8_t byte, twai_message_t *frame, uint8_t msg_
 				if(index == 8)
 				{
 					frame->extd = 1;
-					frame->identifier = (((id[7]<<4)+id[6]) & 0xFF) |
-							((((id[5]<<4)+id[4]) << 8) & 0x0000FF00) |
-							((((id[3]<<4)+id[2]) << 16) & 0x00FF0000) |
-							((((id[1]<<4)+id[0]) << 24) & 0xFF000000);
+					frame->identifier = (((id[6]<<4)+id[7]) & 0xFF) |
+							((((id[4]<<4)+id[5]) << 8) & 0x0000FF00) |
+							((((id[2]<<4)+id[3]) << 16) & 0x00FF0000) |
+							((((id[0]<<4)+id[1]) << 24) & 0xFF000000);
 					frame_state = SL_FRAME_DLC;
 					index = 0;
 				}
@@ -257,7 +257,7 @@ static uint8_t slcan_set_frame(uint8_t byte, twai_message_t *frame, uint8_t msg_
 				if(index == 3)
 				{
 					frame->extd = 0;
-					frame->identifier = (((id[2]<<4)+id[1]) & 0xFF) |
+					frame->identifier = (((id[1]<<4)+id[2]) & 0xFF) |
 							((id[0]<<8) & 0x00000F00) ;
 					frame_state = SL_FRAME_DLC;
 					index = 0;


### PR DESCRIPTION
Found bug where bytes of CAN ID are swapped when sending to the bus. The following should fix it

![Screenshot_2022-09-23_22-58-08](https://user-images.githubusercontent.com/113510586/191965808-4e48a246-98bf-4910-885f-7287b5232dab.png)

Test commands:
ip link set can0 up txqueuelen 1000 type can bitrate 500000
slcand -o -c -s6 -f -F /dev/ttyACM0 -S 4000000
ip link set up dev slcan0 txqueuelen 1000

cansend slcan0 123#1234567890abcdef
cansend slcan0 456#1234567890abcdef
cansend slcan0 12345678#1234567890abcdef
cansend slcan0 17654321#1234567890abcdef


