### PR TITLE
update elm327

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -135,7 +135,7 @@ static void can_tx_task(void *pvParameters)
 		memset(ucTCP_RX_Buffer.ucElement,0, DEV_BUFFER_LENGTH);
 		xQueueReceive(xMsg_Rx_Queue, &ucTCP_RX_Buffer, portMAX_DELAY);
 
-		ESP_LOG_BUFFER_HEX(TAG, ucTCP_RX_Buffer.ucElement, ucTCP_RX_Buffer.usLen);
+		ESP_LOG_BUFFER_HEXDUMP(TAG, ucTCP_RX_Buffer.ucElement, ucTCP_RX_Buffer.usLen, ESP_LOG_INFO);
 
 		uint8_t* msg_ptr = ucTCP_RX_Buffer.ucElement;
 		int temp_len = ucTCP_RX_Buffer.usLen;
@@ -254,10 +254,8 @@ static void can_rx_task(void *pvParameters)
 				}
 				else if(protocol == OBD_ELM327)
 				{
-					if((rx_msg.identifier >= 0x7E8 && rx_msg.identifier <= 0x7EF) || (rx_msg.identifier >= 0x18DAF100 && rx_msg.identifier <= 0x18DAF1FF))
-					{
-						xQueueSend( xmsg_obd_rx_queue, ( void * ) &rx_msg, pdMS_TO_TICKS(0) );
-					}
+					// Let elm327.c decide which messages to process
+					xQueueSend( xmsg_obd_rx_queue, ( void * ) &rx_msg, pdMS_TO_TICKS(0) );
 				}
 
 


### PR DESCRIPTION
- let elm327 handle all CAN messages
- support the CP command to set the priority bytes
- remove special handling of service 1 and 9
- make the optional "odd" digit in the elm327 CAN command work with any size CAN command
- fix an error in the "odd" digit length logic
- error handling of CAN commands that are too long
- when a CAN message is received and the PCI is greater than 7, forward it on, it will probably be a CAN-TP first frame
- reset the config on the D command
- handle but basically ignore the D0 and D1 commands.
- handle the SH command better, save the header and compute the identifier from the priority bytes when a CAN command is sent
- don't reset the header when the protocol is changed
- use the twai extd flag to decide which identifiers to receive
- support the CRA command to customize the receive filter
- reset the config on Z command
- add some disabled logging to help with header/identifier debugging
- in main.c use hexdump logging to show the ascii value of incoming serial messages