### PR TITLE
atto3.json: add missing parenthesis in SOC expression

### DIFF
--- a/vehicle_profiles/byd/atto3.json
+++ b/vehicle_profiles/byd/atto3.json
@@ -7,7 +7,7 @@
             "parameters": [
                 {
                     "name": "SOC",
-                    "expression": "(B5*256)+B4)/100",
+                    "expression": "((B5*256)+B4)/100",
                     "unit": "%",
                     "class": "battery"
                 }


### PR DESCRIPTION
Fixes this error:
```json
{
  "error": "Failed Expression: (B5*256)+B4)/100"
}
```