### PR TITLE
Take a single bit in expression to select charging port status.

### DIFF
--- a/main/expression_parser.c
+++ b/main/expression_parser.c
@@ -138,7 +138,15 @@ bool evaluate_expression(uint8_t *expression, uint8_t *data, double V, double *r
                 index = index * 10 + (expression[i] - '0');
                 i++;
             }
-            push(&operandStack, data[index]);
+            uint8_t value = data[index];
+            if (expression[i] == ':') {
+                i++;
+                uint8_t bit = expression[i] - '0';
+                value = (value >> bit) & 1;
+                i++;
+            }
+
+            push(&operandStack, value);
         } else if (expression[i] == '(') {
             push(&operatorStack, expression[i]);
             i++;

--- a/vehicle_profiles/hyundai/ioniq-2017.json
+++ b/vehicle_profiles/hyundai/ioniq-2017.json
@@ -3,13 +3,33 @@
   "init": "ATSP6;ATSH7E4;ATST96;",
   "pids": [
     {
-      "pid": "21057",
+      "pid": "2105",
       "parameters": [
         {
-          "name": "SOC_DISPLAY",
+          "name": "soc_display",
           "expression": "B39/2",
           "unit": "%",
           "class": "battery"
+        },
+        {
+          "name": "soh",
+          "expression": "[B33:B34]/10",
+          "unit": "%"
+        }
+      ]
+    },
+    {
+      "pid": "2101",
+      "parameters": [
+        {
+          "name": "soc_bms",
+          "expression": "B09/2",
+          "unit": "%",
+          "class": "battery"
+        },
+        {
+          "name": "port_status",
+          "expression": "B14:5"
         }
       ]
     }

--- a/vehicle_profiles/hyundai/ioniq-2017.json
+++ b/vehicle_profiles/hyundai/ioniq-2017.json
@@ -3,16 +3,16 @@
   "init": "ATSP6;ATSH7E4;ATST96;",
   "pids": [
     {
-      "pid": "2105",
+      "pid": "21057",
       "parameters": [
         {
-          "name": "soc_display",
+          "name": "SOC_DISPLAY",
           "expression": "B39/2",
           "unit": "%",
           "class": "battery"
         },
         {
-          "name": "soh",
+          "name": "SOH",
           "expression": "[B33:B34]/10",
           "unit": "%"
         }
@@ -22,14 +22,22 @@
       "pid": "2101",
       "parameters": [
         {
-          "name": "soc_bms",
+          "name": "SOC_BMS",
           "expression": "B09/2",
           "unit": "%",
           "class": "battery"
         },
         {
-          "name": "port_status",
+          "name": "Charger_Connected",
           "expression": "B14:5"
+        },
+        {
+          "name": "Charging",
+          "expression": "B14:7"
+        },
+        {
+          "name": "HV_Charger_Connected",
+          "expression": "B14:6"
         }
       ]
     }

--- a/vehicle_profiles/hyundai/ioniq-2017.json
+++ b/vehicle_profiles/hyundai/ioniq-2017.json
@@ -14,7 +14,8 @@
         {
           "name": "SOH",
           "expression": "[B33:B34]/10",
-          "unit": "%"
+          "unit": "%",
+          "class": ""
         }
       ]
     },
@@ -29,15 +30,21 @@
         },
         {
           "name": "Charger_Connected",
-          "expression": "B14:5"
+          "expression": "B14:5",
+          "unit": "",
+          "class": ""
         },
         {
           "name": "Charging",
-          "expression": "B14:7"
+          "expression": "B14:7",
+          "unit": "",
+          "class": ""
         },
         {
           "name": "HV_Charger_Connected",
-          "expression": "B14:6"
+          "expression": "B14:6",
+          "unit": "",
+          "class": ""
         }
       ]
     }

--- a/vehicle_profiles/kia/niro-phev.json
+++ b/vehicle_profiles/kia/niro-phev.json
@@ -14,7 +14,8 @@
           {
             "name": "SOH",
             "expression": "[B44:B45]/10",
-            "unit": "%"
+            "unit": "%",
+            "class": ""
           }
         ]
       },
@@ -29,7 +30,9 @@
           },
           {
             "name": "Charger_Connected",
-            "expression": "B14:7"
+            "expression": "B14:7",
+            "unit": "",
+            "class": ""
           }
         ]
       }

--- a/vehicle_profiles/kia/niro-phev.json
+++ b/vehicle_profiles/kia/niro-phev.json
@@ -6,13 +6,13 @@
         "pid": "2105",
         "parameters": [
           {
-            "name": "soc_display",
+            "name": "SOC_DISPLAY",
             "expression": "B47/2",
             "unit": "%",
             "class": "battery"
           },
           {
-            "name": "soh",
+            "name": "SOH",
             "expression": "[B44:B45]/10",
             "unit": "%"
           }
@@ -22,13 +22,13 @@
         "pid": "2101",
         "parameters": [
           {
-            "name": "soc_bms",
+            "name": "SOC_BMS",
             "expression": "B09/2",
             "unit": "%",
             "class": "battery"
           },
           {
-            "name": "port_status",
+            "name": "Charger_Connected",
             "expression": "B14:7"
           }
         ]

--- a/vehicle_profiles/kia/niro-phev.json
+++ b/vehicle_profiles/kia/niro-phev.json
@@ -1,0 +1,38 @@
+{
+    "car_model": "Kia: Niro PHEV",
+    "init": "ATSP6;ATSH7E4;ATST96;",
+    "pids": [
+      {
+        "pid": "2105",
+        "parameters": [
+          {
+            "name": "soc_display",
+            "expression": "B47/2",
+            "unit": "%",
+            "class": "battery"
+          },
+          {
+            "name": "soh",
+            "expression": "[B44:B45]/10",
+            "unit": "%"
+          }
+        ]
+      },
+      {
+        "pid": "2101",
+        "parameters": [
+          {
+            "name": "soc_bms",
+            "expression": "B09/2",
+            "unit": "%",
+            "class": "battery"
+          },
+          {
+            "name": "port_status",
+            "expression": "B14:7"
+          }
+        ]
+      }
+    ]
+  }
+  


### PR DESCRIPTION
Take a single bit in expression to select charging port status. 
Add vehicle profiles for Kia Niro and more properties to Hyundai Ioniq

Expressions now support using B14:5 to take the 5th bit (32) from the 14 byte in the payload.

Would be nice if these could show up as a binary sensors in home assistant.