### PR TITLE
consider raw value offset of 20 for e-Golf SOC

### DIFF
--- a/vehicle_profiles/vw/e-golf.json
+++ b/vehicle_profiles/vw/e-golf.json
@@ -7,7 +7,7 @@
       "parameters": [
         {
           "name": "SOC",
-          "expression": "(B4*10)/22",
+          "expression": "((B4-20)*10)/22",
           "unit": "%",
           "class": "battery"
         }


### PR DESCRIPTION
According to the discussion in #168 a raw value of 20 is 0% and 240=100%.
When considering the offset of 20 the SOC matches with the one reported by the VW App.