### PR TITLE
Add configuration for gen2 Volt

### DIFF
--- a/vehicle_profiles/chevrolet/volt.json
+++ b/vehicle_profiles/chevrolet/volt.json
@@ -1,0 +1,13 @@
+{
+  "car_model": "Chevrolet: Volt Gen2",
+  "init": "ATSP6;ATST96;",
+  "pids": [
+    {
+      "pid": "22005B",
+      "pid_init": "ATSH7E0",
+      "parameters": {
+        "SOC": "(B4*100)/255"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Specifying gen2 as I have no way of knowing if the gen1 uses the same config.