### PR TITLE
add extends for profiles, with other minor fixes

### DIFF
--- a/.github/workflows/vehicle_profiles.yml
+++ b/.github/workflows/vehicle_profiles.yml
@@ -11,27 +11,14 @@ on:
 
 jobs:
   build:
-    # Avoid infinite loop on the auto-generated commit
-    if: "!contains(github.event.head_commit.message, 'Build Vehicle Profiles')"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # full history so we can rebase
-          persist-credentials: true
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-      - name: Sync with latest main (rebase)
-        run: |
-          git fetch origin main
-          # If we are behind, rebase; if up-to-date, this is a no-op
-          git pull --rebase origin main || {
-            echo 'Rebase failed';
-            exit 1;
-          }
       - run: |
           cd .vehicle_profiles
           npm ci
@@ -42,7 +29,7 @@ jobs:
       - name: Commit
         uses: EndBug/add-and-commit@v9
         with:
-          add: 'vehicle_profiles.json docs/content/0.Config/6.Automate/2.Supported_Vehicles.md vehicle_profiles/ .vehicle_profiles/'
+          add: 'vehicle_profiles.json docs/content/0.Config/6.Automate/2.Supported_Vehicles.md docs/content/0.Config/6.Automate/4.Supported_Parameters.md vehicle_profiles/ .vehicle_profiles/'
           author_name: Jay Oswald
           author_email: jay@oswald.net.au
           message: Commit from GitHub Actions (Build Vehicle Profiles)

--- a/.github/workflows/vehicle_profiles.yml
+++ b/.github/workflows/vehicle_profiles.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Commit
         uses: EndBug/add-and-commit@v9
         with:
-          add: 'vehicle_profiles.json docs/content/0.Config/6.Automate/2.Supported_Vehicles.md docs/content/0.Config/6.Automate/4.Supported_Parameters.md vehicle_profiles/ .vehicle_profiles/'
           author_name: Jay Oswald
           author_email: jay@oswald.net.au
           message: Commit from GitHub Actions (Build Vehicle Profiles)

--- a/.vehicle_profiles/schema.json
+++ b/.vehicle_profiles/schema.json
@@ -22,6 +22,10 @@
       "description": "Init String, don't forget the final ;",
       "type": "string"
     },
+    "extends": {
+      "description": "Allows 1 profile to extend another",
+      "type": "string"
+    },
     "pids": {
       "description": "Array of PID's and their parameters",
       "type": "array",

--- a/.vehicle_profiles/src/md/supported-vehicles.md
+++ b/.vehicle_profiles/src/md/supported-vehicles.md
@@ -1,7 +1,9 @@
-# <!--
+---
+title: "Supported Vehicles"
+---
 
+<!--
 # THIS FILE WAS GENERATED! DO NOT UPDATE OR YOUR CHANGES ARE LOST!
-
 -->
 
 # ⚠️ Important Note

--- a/vehicle_profiles/hyundai/kona.json
+++ b/vehicle_profiles/hyundai/kona.json
@@ -1,0 +1,5 @@
+{
+  "car_model": "Hyundai: Kona",
+  "init": "ATSH7E4;ATST96;",
+  "extends": "hyundai/ioniq5-6.json"
+}

--- a/vehicle_profiles/kia/nirosoulkona-ev.json
+++ b/vehicle_profiles/kia/nirosoulkona-ev.json
@@ -1,5 +1,5 @@
 {
-  "car_model": "Kia/Hyundai: Niro/Soul/Kona",
+  "car_model": "Kia: Niro/Soul",
   "init": "ATST96;",
   "pids": [
     {


### PR DESCRIPTION
* cleanup vehicle profiles action, remove un-necesary parts, comitting everything, as some paths are dynamic. Anything we touch should be comitted anyway
* Adding extends to vehicle profiles, so profiles can extend other profiles (at any depth)
* Writing the main `vehicle_profiles.json` in pretty format instead of compressed. Its only ever read by browser on wican, or manually. So the extra readibility is much better than slightly smaller size now, makes debugging much easier
* Fixing title for supported vehicles docs page
* Adding Kona profile, as example of extends