### PR TITLE
Add Ford Focus RS MK3 vehicle profile

### DIFF
--- a/vehicle_profiles/ford/focus_rs_mk3.json
+++ b/vehicle_profiles/ford/focus_rs_mk3.json
@@ -1,0 +1,90 @@
+{
+  "car_model": "Ford: Focus RS (MK3)",
+  "init": "ATE0;ATL0;ATH0;ATR1;ATST32;ATSP6;ATCAF1;",
+  "pids": [
+    {
+      "pid": "224028",
+      "pid_init": "ATSH000726;STCAFCP726,72E;",
+      "parameters": {
+        "SOC": "B4"
+      }
+    },
+    {
+      "pid": "222813",
+      "pid_init": "ATSH000726;STCAFCP726,72E;",
+      "parameters": {
+        "TYRE_P_FL": "([B4:B5]/10)/2.036"
+      }
+    },
+    {
+      "pid": "222816",
+      "pid_init": "ATSH000726;STCAFCP726,72E;",
+      "parameters": {
+        "TYRE_P_RL": "([B4:B5]/10)/2.036"
+      }
+    },
+    {
+      "pid": "222814",
+      "pid_init": "ATSH000726;STCAFCP726,72E;",
+      "parameters": {
+        "TYRE_P_FR": "([B4:B5]/10)/2.036"
+      }
+    },
+    {
+      "pid": "222815",
+      "pid_init": "ATSH000726;STCAFCP726,72E;",
+      "parameters": {
+        "TYRE_P_RR": "([B4:B5]/10)/2.036"
+      }
+    },
+    {
+      "pid": "22F405",
+      "pid_init": "ATSH7E0;STCAFCP7E0,7E8;",
+      "parameters": {
+        "COOLANT_TMP": "B4-40"
+      }
+    },
+    {
+      "pid": "22F40F",
+      "pid_init": "ATSH7E0;STCAFCP7E0,7E8;",
+      "parameters": {
+        "INTAKE_AIR_TMP": "B4-40"
+      }
+    },
+    {
+      "pid": "2203CA",
+      "pid_init": "ATSH7E0;STCAFCP7E0,7E8;",
+      "parameters": {
+        "INTAKE_AIR_TEMP_2": "B4-40"
+      }
+    },
+    {
+      "pid": "22dd01",
+      "pid_init": "ATSH000726;STCAFCP726,72E;",
+      "parameters": {
+        "ODOMETER": "[B4:B6]"
+      }
+    },
+    {
+      "pid": "22dd04",
+      "pid_init": "ATSH000726;STCAFCP726,72E;",
+      "parameters": {
+        "T_CAB": "(B4*10/9)-45"
+      }
+    },
+    {
+      "pid": "224029",
+      "pid_init": "ATSH000726;STCAFCP726,72E;",
+      "parameters": {
+        "BATT_TEMP": "B4-40"
+      }
+    },
+    {
+      "pid": "22f42f",
+      "pid_init": "ATSH7E0;STCAFCP7E0,7E8;",
+      "parameters": {
+        "FUEL": "(B4/255)*100"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This profile tracks some basic PIDs for Ford Focus RS MK3 (tested on a 2017). For now this provides the basics I need for my automations in Home Assistant. I've been running this profile reliably for several weeks now.