### PR TITLE
Add Outlander-PHEV 2025 profile with tested PIDs

### DIFF
--- a/vehicle_profiles/mitsubishi/outlander-2025.json
+++ b/vehicle_profiles/mitsubishi/outlander-2025.json
@@ -13,7 +13,7 @@
       "pid": "220375",
       "pid_init": "ATSH18DB33F1;ATCRA18DAF1DB;",
       "parameters": {
-        "SOC_REAL": "B5/2"
+        "SOC_D": "B5/2"
       }
     },
     {


### PR DESCRIPTION
Adds vehicle profile for 2025 Mitsubishi Outlander-PHEV with:
- SOC: State of charge (from 2023 profile)
- SOC_D: Displayed State of Charge (PID 220375)
- HV_V: High voltage battery voltage (PID 220387)
Found from various links on the interwebs.
Expressions confirmed working via live testing on 2025 vehicle.
