### PR TITLE
Fix ODOMETER for the Kia Niro EV profile

### DIFF
--- a/vehicle_profiles/kia/niro-ev.json
+++ b/vehicle_profiles/kia/niro-ev.json
@@ -38,11 +38,11 @@
       }
     },
     {
-      "pid": "22B002",
-      "pid_init": "ATSH7C6;ATFCSH7C6",
+      "pid": "22B0023",
+      "pid_init": "ATSH7C6;ATFCSH7C6;",
       "parameters": {
-        "ODOMETER": "[B5:B6]"
-      }
+        "ODOMETER": "[B12:B14]"
+      } 
     }
   ]
 }


### PR DESCRIPTION
copied @jay-oswald's great fix for the ODOMETER parameter on the Hyundai Kona (vehicle_profiles/hyundai/kona.json) to the Kia Niro EV profile (vehicle_profiles/kia/niro-ev.json) since it uses the same logic