### PR TITLE
Add optional "car_on_param" to gate some low-voltage state transitions.

### DIFF
--- a/components/autopid/autopid.c
+++ b/components/autopid/autopid.c
@@ -124,6 +124,26 @@ static cJSON *autopid_add_parameter_number_to_object(cJSON *object,
     return cJSON_AddNumberToObject(object, name, autopid_round_parameter_value((double)value));
 }
 
+/* Seconds since boot at which LDC_A was last seen > 1.0; -1 = never.
+ * int32_t is written and read atomically on the 32-bit Xtensa LX7 core,
+ * avoiding the torn-read race that a 64-bit µs timestamp would have. */
+static volatile int32_t s_last_car_on_valid_stamp = -1;
+
+static void autopid_pid_update_hook(parameter_t *param, float value)
+{
+    if (!autopid_config->car_on_param)
+        return;
+    if (param->name && strcmp(param->name, autopid_config->car_on_param) == 0 && value >= 0.5f)
+        s_last_car_on_valid_stamp = (int32_t)(esp_timer_get_time() / 1000000ULL);
+}
+
+bool autopid_car_is_on(void)
+{
+    int32_t t = s_last_car_on_valid_stamp;
+    return t >= 0 &&
+           ((int32_t)(esp_timer_get_time() / 1000000ULL) - t) < 10;
+}
+
 static bool autopid_prepare_parameter_value(parameter_t *param,
                                             double raw_value,
                                             float *out_value,
@@ -165,6 +185,7 @@ static bool autopid_prepare_parameter_value(parameter_t *param,
     }
 
     *out_value = (float)rounded_value;
+    autopid_pid_update_hook(param, *out_value);
     return true;
 }
 // strdup_psram
@@ -3801,7 +3822,7 @@ static void autopid_task(void *pvParameters)
         static bool pid_polling_paused_prev = false;
 
         dev_status_wait_for_bits(DEV_AUTOPID_ELM327_APP_BIT, portMAX_DELAY);
-        
+
         if (dev_status_is_sleeping())
         {
             ESP_LOGI(TAG, "Device is sleeping, waiting for wakeup");

--- a/components/autopid/autopid.h
+++ b/components/autopid/autopid.h
@@ -203,6 +203,11 @@ typedef struct
     uint32_t cycle;     //To be removed when std pid gets its own period
     time_t last_successful_pid_time;  // Timestamp in seconds since epoch of last successful PID response
     SemaphoreHandle_t mutex;
+    // Name of the autopid parameter used as "car ON" indicator.
+    // When non-NULL and the named parameter reports a value >= 1.0, the sleep
+    // state machine suppresses sleep transition,
+    // NULL means the feature is disabled.
+    const char *car_on_param;
 } autopid_config_t;
 
 typedef struct 
@@ -224,6 +229,7 @@ esp_err_t autopid_set_protocol_number(int32_t protocol_value);
 esp_err_t autopid_get_protocol_number(int32_t *protocol_value);
 
 char *autopid_get_value_by_name(char* name);
+bool autopid_car_is_on(void);
 void autopid_publish_all_destinations(void);
 void autopid_app_reset_timer(void);
 

--- a/components/autopid/autopid_config.c
+++ b/components/autopid/autopid_config.c
@@ -36,6 +36,7 @@
 #include "hw_config.h"
 #include "obd2_standard_pids.h"
 #include "autopid_config.h"
+#include "config_server.h"
 #define TAG "AUTO_PID_CFG"
 
 // Forward declaration (implemented in autopid.c)
@@ -1240,6 +1241,9 @@ autopid_config_t *load_autopid_config(void)
     parse_car_data_json(autopid_config, &pid_index);
 
     autopid_config->pid_count = total_pids;
+
+    // Point directly into device_config — no copy needed, it's constant for the session.
+    autopid_config->car_on_param = config_server_get_car_on_param();
 
     return autopid_config;
 }

--- a/main/config_server.c
+++ b/main/config_server.c
@@ -1801,6 +1801,7 @@ char *config_server_get_status_json(bool remove_sensitive_info)
 	cJSON_AddStringToObject(root, "wakeup_volt", device_config.wakeup_volt);
 	cJSON_AddStringToObject(root, "periodic_wakeup", device_config.periodic_wakeup);
 	cJSON_AddStringToObject(root, "wakeup_interval", device_config.wakeup_interval);
+	cJSON_AddStringToObject(root, "car_on_param", device_config.car_on_param);
 
 	cJSON_AddStringToObject(root, "batt_alert", device_config.batt_alert);
 	if(!remove_sensitive_info)
@@ -3313,7 +3314,20 @@ static void config_server_load_cfg(char *cfg)
 	}
 
 	ESP_LOGI(TAG, "device_config.wakeup_interval: %s", device_config.wakeup_interval);
-	//*****	
+	//*****
+
+	//*****
+	key = cJSON_GetObjectItem(root, "car_on_param");
+	if (key == 0 || key->valuestring == NULL)
+	{
+		device_config.car_on_param[0] = '\0'; // disabled by default
+	}
+	else
+	{
+		strlcpy(device_config.car_on_param, key->valuestring, sizeof(device_config.car_on_param));
+	}
+	ESP_LOGI(TAG, "device_config.car_on_param: %s", device_config.car_on_param);
+	//*****
 
 
 	//*****
@@ -3872,6 +3886,11 @@ int8_t config_server_get_wakeup_interval(uint32_t *wakeup_interval)
     
     *wakeup_interval = (uint32_t)wk_int;
     return 1;
+}
+
+const char *config_server_get_car_on_param(void)
+{
+    return device_config.car_on_param[0] != '\0' ? device_config.car_on_param : NULL;
 }
 
 int8_t config_server_get_battery_alert_config(void)

--- a/main/config_server.h
+++ b/main/config_server.h
@@ -132,6 +132,7 @@ typedef struct _device_config
 	char wakeup_time[32];
 	char periodic_wakeup[32];
 	char wakeup_interval[32];
+	char car_on_param[64]; // autopid parameter name to detect car *ON*
 	char batt_alert[32];
 	char batt_alert_ssid[65];
 	char batt_alert_pass[65];
@@ -245,6 +246,7 @@ log_filesystem_t config_server_get_log_filesystem(void);
 int8_t config_server_get_ap_auto_disable(void);
 int8_t config_server_get_periodic_wakeup(void);
 int8_t config_server_get_wakeup_interval(uint32_t *wakeup_interval);
+const char *config_server_get_car_on_param(void);
 int8_t config_server_get_imu_threshold(uint8_t *imu_threshold);
 bool config_server_is_debug_enabled(void);
 bool config_server_get_mqtt_security_enabled(void);

--- a/main/sleep_mode.c
+++ b/main/sleep_mode.c
@@ -599,6 +599,7 @@ int8_t sleep_mode_init(uint8_t enable, float sleep_volt)
 #include "hw_config.h"
 #include "sdcard.h"
 #include "ble.h"
+#include "autopid.h"
 
 #define ADC_UNIT          ADC_UNIT_1
 #define ADC_CONV_MODE     ADC_CONV_SINGLE_UNIT_1
@@ -910,6 +911,8 @@ void light_sleep_task(void *pvParameters)
     vTaskDelay(pdMS_TO_TICKS(1000));
     while (1) 
 	{
+        // The opposite of "car_is_on" is not "off" but "we don't know"
+        bool car_is_on = autopid_car_is_on();
         // Read voltage every 3 seconds
         if(wc_timer_is_expired(&voltage_read_timer)) 
 		{
@@ -920,7 +923,7 @@ void light_sleep_task(void *pvParameters)
             if(ret == ESP_OK)
             {
                 update_battery_voltage(&battery_voltage);
-                if (battery_voltage < sleep_voltage)
+                if (battery_voltage < sleep_voltage && !car_is_on)
                 {
                     dev_status_clear_bits(DEV_WAKE_VOLTAGE_OK_BIT);
                 }
@@ -937,7 +940,7 @@ void light_sleep_task(void *pvParameters)
             switch (current_state) 
 			{
                 case STATE_NORMAL:
-                    if (battery_voltage < sleep_voltage) 
+                    if (battery_voltage < sleep_voltage && !car_is_on)
 					{
                         ESP_LOGW(TAG, "Battery voltage low (%.2fV), starting low voltage timer", battery_voltage);
                         current_state = STATE_LOW_VOLTAGE;
@@ -946,7 +949,7 @@ void light_sleep_task(void *pvParameters)
                     break;
 
                 case STATE_LOW_VOLTAGE:
-                    if (battery_voltage >= wakeup_voltage) 
+                    if (battery_voltage >= wakeup_voltage || car_is_on)
 					{
                         ESP_LOGI(TAG, "Battery voltage recovered (%.2fV)", battery_voltage);
                         current_state = STATE_NORMAL;

--- a/main/web/homepage_full.html
+++ b/main/web/homepage_full.html
@@ -1794,6 +1794,18 @@
                     </td>
                 </tr>
                 <tr>
+                    <td>Car On PID Parameter:</td>
+                    <td>
+                        <input type="text"
+                               id="car_on_param"
+                               name="car_on_param"
+                               placeholder="e.g. LDC_A (leave empty to disable)"
+                               style="width:100%;box-sizing:border-box;"
+                               oninput="submit_enable();">
+                        <small style="color:#6c757d;">Autopid parameter name whose value &gt; 0.5 indicates car is "ON/READY" — suppresses sleep while active.</small>
+                    </td>
+                </tr>
+                <tr>
                     <td>Battery Alert:</td>
                     <td>
                         <select name="batt_alert" id="batt_alert" onchange="submit_enable();">

--- a/main/web/src/main.js
+++ b/main/web/src/main.js
@@ -3488,6 +3488,7 @@ async function postConfig() {
     obj["sleep_volt"] = document.getElementById("sleep_volt").value;
     obj["sleep_time"] = document.getElementById("sleep_time").value;
     obj["wakeup_interval"] = document.getElementById("wakeup_interval").value;
+    obj["car_on_param"] = document.getElementById("car_on_param").value.trim();
     obj["batt_alert"] = document.getElementById("batt_alert").value;
     obj["batt_alert_ssid"] = document.getElementById("batt_alert_ssid").value;
     obj["batt_alert_pass"] = document.getElementById("batt_alert_pass").value;
@@ -4123,6 +4124,7 @@ xhttp.onload = async function() {
         document.getElementById('sleep_time_value').textContent = obj.sleep_time;
         document.getElementById("wakeup_interval").value = obj.wakeup_interval;
         document.getElementById('wakeup_interval_value').textContent = obj.wakeup_interval;
+        document.getElementById("car_on_param").value = obj.car_on_param || "";
         document.getElementById("batt_alert").value = "disable";
         document.getElementById("batt_alert_ssid").value = obj.batt_alert_ssid;
         document.getElementById("batt_alert_pass").value = obj.batt_alert_pass;


### PR DESCRIPTION
Ioniq 5 (or likely all Hyundai/Kia EGMP) can keep AUX_V around 12.7-12.8V
 for extended periods of time while driving (unless low-beams are on).
The same behavior might happen on pure ICE cars with smart alternators.
Wican-pro sometimes then go to sleep while driving.

When "car_on_param" is used the clearing of DEV_WAKE_VOLTAGE_OK and transition to STATE_LOW_VOLTAGE are gated by the fact car is not positively detected as "ON" by designated PID param sometime in the last 10 seconds (i.e. we prevent wican-pro entering sleep state or disabling autopid because of voltage while  PID "<car_on_param>" is >= 0.5).

If that new parameter is not explicitly used, there is absolutely no change to sleep behavior.

On EGMP car, on possibility for car_on_param is "LDC_A" (if LDC is on and currently supplies some non-trivial current, we definitely don't need to sleep).