### PR TITLE
Drop "response pending" frame from UDS answer.

### DIFF
--- a/components/autopid/autopid.c
+++ b/components/autopid/autopid.c
@@ -2292,6 +2292,10 @@ void parse_elm327_response(char *buffer, response_t *response)
                 k++;
                 data_start += 2;
             }
+            if (k ==  4 && memcmp(response->data, "\x03\x7f\x22\x78", 4) == 0) {
+                // This is a "pending" response frame from ECU, ignore/drop that frame
+                k = 0;
+            }
         }
         else
         {


### PR DESCRIPTION
At least on Ioniq-5 when querying unit 7C6/22B002 (for odometer param), the ECU regularly prefix the normal answer with a response-pending frame:
 7CE 03 7F 22 78
 7CE 10 18 62 B0 02 D6 00 00
 7CE 21 00 FF B2 00 00 00 00
 7CE 22 17 50 00 00 B5 00 00
 7CE 23 00 00 00 00 AA AA AA

None of downstream parsing code takes that into account leading to incorrect odometer reading.

Always dropping a response-pending frame brings allows correct odometer reading, and should only have positive side-effects.