### PR TITLE
Add Toyota Prius Prime (Gen2 PHV) vehicle profile

### DIFF
--- a/vehicle_profiles/toyota/prius_prime.json
+++ b/vehicle_profiles/toyota/prius_prime.json
@@ -1,0 +1,19 @@
+{
+  "car_model": "Toyota: Prius Prime (Gen2 PHV)",
+  "comment": "Toyota Prius Prime (Gen2 PHV, 2017-2022). Confirmed on WiCAN-OBD-C3 fw 4.21. HV/EV battery SOC via standard PID 015B (two ECUs respond, hence 015B2), same scaling as the Rav4 profile. Note: unlike the Rav4, the Prius Prime does not respond to standard fuel PID 012F or odometer PID 01A6.",
+  "init": "ATSP6;",
+  "pids": [
+    {
+      "pid": "01051",
+      "parameters": {
+        "COOLANT_TMP": "B3-40"
+      }
+    },
+    {
+      "pid": "015B2",
+      "parameters": {
+        "SOC": "(B3*20)/51"
+      }
+    }
+  ]
+}

--- a/vehicle_profiles/toyota/prius_prime.json
+++ b/vehicle_profiles/toyota/prius_prime.json
@@ -1,18 +1,27 @@
 {
   "car_model": "Toyota: Prius Prime (Gen2 PHV)",
-  "comment": "Toyota Prius Prime (Gen2 PHV, 2017-2022). Confirmed on WiCAN-OBD-C3 fw 4.21. HV/EV battery SOC via standard PID 015B (two ECUs respond, hence 015B2), same scaling as the Rav4 profile. Note: unlike the Rav4, the Prius Prime does not respond to standard fuel PID 012F or odometer PID 01A6.",
+  "comment": "Extends the Rav4 profile (shared TNGA hybrid platform). Confirmed on a WiCAN-OBD-C3 (fw 4.21). Differences from the Rav4: HV/EV SOC (015B) returns two ECU responses, so it is filtered to one with ATCRA; odometer (01A6) returns NO DATA on the Prius Prime, so it is removed; coolant (0105) is added. Standard fuel PID 012F also returns NO DATA on this car.",
+  "extends": "toyota/rav4.json",
   "init": "ATSP6;",
   "pids": [
+    {
+      "pid": "remove",
+      "parameters": {
+        "ODOMETER": "",
+        "SOC": ""
+      }
+    },
+    {
+      "pid": "015B1",
+      "pid_init": "ATCRA7EA;",
+      "parameters": {
+        "SOC": "(B3*20)/51"
+      }
+    },
     {
       "pid": "01051",
       "parameters": {
         "COOLANT_TMP": "B3-40"
-      }
-    },
-    {
-      "pid": "015B2",
-      "parameters": {
-        "SOC": "(B3*20)/51"
       }
     }
   ]


### PR DESCRIPTION
Adds a vehicle profile for the **Toyota Prius Prime (Gen2 PHV, 2017–2022)** in the existing `toyota/` folder (no Prius profile existed yet).

- Coolant temp (`01051` → `COOLANT_TMP`)
- **HV/EV battery SOC** (`015B2` → `SOC`, `(B3*20)/51`) — same PID and scaling as the existing Rav4 profile (two ECUs respond on this platform)

Confirmed on a WiCAN-OBD-C3 (fw 4.21). Reuses existing `params.json` keys (`COOLANT_TMP`, `SOC`), so no `params.json` changes are needed. Passes `npm run validate`.

Note: unlike the Rav4, the Prius Prime does **not** respond to standard fuel PID `012F` or odometer PID `01A6`, so those are intentionally omitted.
