### PR TITLE
Add Opel Ampere-E 2019 vehicle profile

### DIFF
--- a/vehicle_profiles/opel/ampere-e-2019.json
+++ b/vehicle_profiles/opel/ampere-e-2019.json
@@ -1,0 +1,49 @@
+{
+  "car_model": "Opel: Ampere-E 2019",
+  "init": "ATSP6;ATST96;ATSH7E0;ATSH7E1;ATSH7E4;",
+  "pids": [
+    {
+      "pid": "2283341",
+      "pid_init": "ATSH7E4",
+      "parameters": {
+        "SOC": "(B4*100)/255"
+      }
+    },
+    {
+      "pid": "2245F9",
+      "pid_init": "ATSH7E4",
+      "parameters": {
+        "HV_CAPACITY": "((B4*256)+B5)/100",
+        "HV_CAPACITY_KWH": "((B4*256)+B5)*0.0032"
+      }
+    },
+    {
+      "pid": "22434F",
+      "pid_init": "ATSH7E4",
+      "parameters": {
+        "BATT_TEMP": "(B4-40)"
+      }
+    },
+    {
+      "pid": "224369",
+      "pid_init": "ATSH7E4",
+      "parameters": {
+        "AC_C_C": "B4*.2"
+      }
+    },
+    {
+      "pid": "224368",
+      "pid_init": "ATSH7E4",
+      "parameters": {
+        "AC_C_V": "B4*2"
+      }
+    },
+    {
+      "pid": "224533",
+      "pid_init": "ATSH7E4",
+      "parameters": {
+        "CHARGING_R_A": "B4*0.3"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds a dedicated vehicle profile for the 2019 Opel Ampere-E (`vehicle_profiles/opel/ampere-e-2019.json`).

### Why a separate profile (not merged into `ampere-e.json`)

The HV battery capacity PID differs between model years, so the existing profile does not read correctly on the 2019 car:

| Parameter | `ampere-e.json` (2017–2019) | this profile (2019) |
|---|---|---|
| HV_CAPACITY PID | `2241A31` → `[B4:B5]/10` | `2245F9` → `((B4*256)+B5)/100` |

Because the request PID itself is different (not just the scaling), the two cannot share one `pids` entry. SOC uses the same PID (`2283341`) on both. This profile also adds a few parameters I found useful on the 2019 car (capacity in kWh, battery temperature, and AC charger values).

### Parameters

- **SOC** — state of charge
- **HV_CAPACITY** / **HV_CAPACITY_KWH** — HV battery capacity in Ah and kWh
- **BATT_TEMP** — battery temperature
- **AC_C_C** / **AC_C_V** — AC charging current and voltage
- **CHARGING_R_A** — requested charge current

All parameter names come from the existing controlled vocabulary in `schema.json` / `params.json`, so no `params.json` changes are needed.

Happy to instead fold this into `ampere-e.json` using `extends`/year handling if the maintainers prefer a single file — let me know.
