### PR TITLE
Unit and Class consistency improvements

### DIFF
--- a/.vehicle_profiles/params.json
+++ b/.vehicle_profiles/params.json
@@ -10,7 +10,7 @@
     "description": "AC Charging Current",
     "settings": {
       "unit": "A",
-      "class": "battery"
+      "class": "current"
     }
   },
   "AC_C_V": {
@@ -287,7 +287,7 @@
     "description": "High Voltage Battery Power Available",
     "settings": {
       "unit": "kW",
-      "class": "battery"
+      "class": "power"
     }
   },
   "HV_CAPACITY": {
@@ -301,14 +301,14 @@
     "description": "HV Battery capacity in kWh",
     "settings": {
       "unit": "kWh",
-      "class": "none"
+      "class": "energy"
     }
   },
   "HV_CAPACITY_R": {
     "description": "HV Battery capacity Remaining",
     "settings": {
       "unit": "kWh",
-      "class": "none"
+      "class": "energy"
     }
   },
   "HV_C_DIFF": {
@@ -2117,7 +2117,7 @@
     "description": "Battery Remaining Energy",
     "settings": {
       "unit": "Wh",
-      "class": "battery",
+      "class": "energy",
       "min": "0",
       "max": "77000"
     }
@@ -2508,8 +2508,8 @@
   "KWH_CHARGED": {
     "description": "Total kWh Charged (Cumulative Energy Charged)",
     "settings": {
-      "unit": "kwh",
-      "class": "battery",
+      "unit": "kWh",
+      "class": "energy",
       "min": "0",
       "max": "1000000"
     }
@@ -2518,7 +2518,7 @@
     "description": "Total kWH Discharged( Cumulative Energy Discharged)",
     "settings": {
       "unit": "kWh",
-      "class": "none",
+      "class": "energy",
       "min": "0",
       "max": "1000000"
     }

--- a/vehicle_profiles.json
+++ b/vehicle_profiles.json
@@ -174,7 +174,7 @@
               "name": "HV_CAPACITY_KWH",
               "expression": "[B4:B5]*50",
               "unit": "kWh",
-              "class": "none"
+              "class": "energy"
             }
           ]
         },
@@ -263,7 +263,7 @@
               "name": "HV_AV",
               "expression": "(((150000-[B10:B13])/100)*([B6:B7]/4))/1000",
               "unit": "kW",
-              "class": "battery"
+              "class": "power"
             }
           ]
         },
@@ -1443,13 +1443,13 @@
               "name": "LV_V",
               "expression": "B38*0.1",
               "unit": "V",
-              "class": "battery"
+              "class": "voltage"
             },
             {
               "name": "KWH_CHARGED",
               "expression": "([B49:B50]*65536 + [B51:B52])/10",
-              "unit": "kwh",
-              "class": "battery",
+              "unit": "kWh",
+              "class": "energy",
               "min": "0",
               "max": "1000000"
             }
@@ -1552,7 +1552,7 @@
               "name": "HV_CAPACITY_R",
               "expression": "[B4:B5]/100",
               "unit": "kWh",
-              "class": "none"
+              "class": "energy"
             }
           ]
         },
@@ -1627,7 +1627,7 @@
               "name": "HV_CAPACITY_KWH",
               "expression": "[B6:B7]/10",
               "unit": "kWh",
-              "class": "none"
+              "class": "energy"
             }
           ]
         },
@@ -1877,13 +1877,13 @@
               "name": "LV_V",
               "expression": "B38/10",
               "unit": "V",
-              "class": "battery"
+              "class": "voltage"
             },
             {
               "name": "KWH_CHARGED",
               "expression": "([B49:B50]*65536+[B51:B52])/10",
-              "unit": "kwh",
-              "class": "battery",
+              "unit": "kWh",
+              "class": "energy",
               "min": "0",
               "max": "1000000"
             }
@@ -2152,7 +2152,7 @@
               "name": "HV_C_DIFF",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "4"
             },
@@ -2256,7 +2256,7 @@
               "name": "HV_KWH_R",
               "expression": "((B37 << 8) + B38) *2",
               "unit": "Wh",
-              "class": "battery",
+              "class": "energy",
               "min": "0",
               "max": "77000"
             },
@@ -2296,7 +2296,7 @@
               "name": "LV_V",
               "expression": "B38*0.1",
               "unit": "V",
-              "class": "battery"
+              "class": "voltage"
             },
             {
               "name": "HV_T_MAX",
@@ -2377,8 +2377,8 @@
             {
               "name": "KWH_CHARGED",
               "expression": "((B49<<24)+(B50<<16)+(B51<<8)+B52)/10",
-              "unit": "kwh",
-              "class": "battery",
+              "unit": "kWh",
+              "class": "energy",
               "min": "0",
               "max": "1000000"
             },
@@ -2386,7 +2386,7 @@
               "name": "KWH_DISCHARGED",
               "expression": "((B53<<24)+(B54<<16)+(B55<<8)+B57)/10",
               "unit": "kWh",
-              "class": "none",
+              "class": "energy",
               "min": "0",
               "max": "1000000"
             },
@@ -2409,7 +2409,7 @@
               "name": "CAPACITOR",
               "expression": "((B63<<8)+B35)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "840"
             },
@@ -2671,7 +2671,7 @@
               "name": "HV_C_DIFF",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "4"
             },
@@ -2775,7 +2775,7 @@
               "name": "HV_KWH_R",
               "expression": "((B37 << 8) + B38) *2",
               "unit": "Wh",
-              "class": "battery",
+              "class": "energy",
               "min": "0",
               "max": "77000"
             },
@@ -2815,7 +2815,7 @@
               "name": "LV_V",
               "expression": "B38*0.1",
               "unit": "V",
-              "class": "battery"
+              "class": "voltage"
             },
             {
               "name": "HV_T_MAX",
@@ -2896,8 +2896,8 @@
             {
               "name": "KWH_CHARGED",
               "expression": "((B49<<24)+(B50<<16)+(B51<<8)+B52)/10",
-              "unit": "kwh",
-              "class": "battery",
+              "unit": "kWh",
+              "class": "energy",
               "min": "0",
               "max": "1000000"
             },
@@ -2905,7 +2905,7 @@
               "name": "KWH_DISCHARGED",
               "expression": "((B53<<24)+(B54<<16)+(B55<<8)+B57)/10",
               "unit": "kWh",
-              "class": "none",
+              "class": "energy",
               "min": "0",
               "max": "1000000"
             },
@@ -2928,7 +2928,7 @@
               "name": "CAPACITOR",
               "expression": "((B63<<8)+B35)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "840"
             },
@@ -3140,7 +3140,7 @@
               "name": "HV_C_V_001",
               "expression": "B10/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3148,7 +3148,7 @@
               "name": "HV_C_V_002",
               "expression": "B11/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3156,7 +3156,7 @@
               "name": "HV_C_V_003",
               "expression": "B12/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3164,7 +3164,7 @@
               "name": "HV_C_V_004",
               "expression": "B13/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3172,7 +3172,7 @@
               "name": "HV_C_V_005",
               "expression": "B14/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3180,7 +3180,7 @@
               "name": "HV_C_V_006",
               "expression": "B15/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3188,7 +3188,7 @@
               "name": "HV_C_V_007",
               "expression": "B17/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3196,7 +3196,7 @@
               "name": "HV_C_V_008",
               "expression": "B18/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3204,7 +3204,7 @@
               "name": "HV_C_V_009",
               "expression": "B19/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3212,7 +3212,7 @@
               "name": "HV_C_V_010",
               "expression": "B20/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3220,7 +3220,7 @@
               "name": "HV_C_V_011",
               "expression": "B21/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3228,7 +3228,7 @@
               "name": "HV_C_V_012",
               "expression": "B22/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3236,7 +3236,7 @@
               "name": "HV_C_V_013",
               "expression": "B23/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3244,7 +3244,7 @@
               "name": "HV_C_V_014",
               "expression": "B25/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3252,7 +3252,7 @@
               "name": "HV_C_V_015",
               "expression": "B26/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3260,7 +3260,7 @@
               "name": "HV_C_V_016",
               "expression": "B27/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3268,7 +3268,7 @@
               "name": "HV_C_V_017",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3276,7 +3276,7 @@
               "name": "HV_C_V_018",
               "expression": "B29/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3284,7 +3284,7 @@
               "name": "HV_C_V_019",
               "expression": "B30/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3292,7 +3292,7 @@
               "name": "HV_C_V_020",
               "expression": "B31/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3300,7 +3300,7 @@
               "name": "HV_C_V_021",
               "expression": "B33/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3308,7 +3308,7 @@
               "name": "HV_C_V_022",
               "expression": "B34/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3316,7 +3316,7 @@
               "name": "HV_C_V_023",
               "expression": "B35/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3324,7 +3324,7 @@
               "name": "HV_C_V_024",
               "expression": "B36/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3332,7 +3332,7 @@
               "name": "HV_C_V_025",
               "expression": "B37/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3340,7 +3340,7 @@
               "name": "HV_C_V_026",
               "expression": "B38/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3348,7 +3348,7 @@
               "name": "HV_C_V_027",
               "expression": "B39/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3356,7 +3356,7 @@
               "name": "HV_C_V_028",
               "expression": "B41/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3364,7 +3364,7 @@
               "name": "HV_C_V_029",
               "expression": "B42/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3372,7 +3372,7 @@
               "name": "HV_C_V_030",
               "expression": "B43/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3380,7 +3380,7 @@
               "name": "HV_C_V_031",
               "expression": "B44/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3388,7 +3388,7 @@
               "name": "HV_C_V_032",
               "expression": "B45/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             }
@@ -3402,7 +3402,7 @@
               "name": "HV_C_V_033",
               "expression": "B10/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3410,7 +3410,7 @@
               "name": "HV_C_V_034",
               "expression": "B11/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3418,7 +3418,7 @@
               "name": "HV_C_V_035",
               "expression": "B12/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3426,7 +3426,7 @@
               "name": "HV_C_V_036",
               "expression": "B13/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3434,7 +3434,7 @@
               "name": "HV_C_V_037",
               "expression": "B14/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3442,7 +3442,7 @@
               "name": "HV_C_V_038",
               "expression": "B15/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3450,7 +3450,7 @@
               "name": "HV_C_V_039",
               "expression": "B17/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3458,7 +3458,7 @@
               "name": "HV_C_V_040",
               "expression": "B18/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3466,7 +3466,7 @@
               "name": "HV_C_V_041",
               "expression": "B19/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3474,7 +3474,7 @@
               "name": "HV_C_V_042",
               "expression": "B20/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3482,7 +3482,7 @@
               "name": "HV_C_V_043",
               "expression": "B21/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3490,7 +3490,7 @@
               "name": "HV_C_V_044",
               "expression": "B22/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3498,7 +3498,7 @@
               "name": "HV_C_V_045",
               "expression": "B23/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3506,7 +3506,7 @@
               "name": "HV_C_V_046",
               "expression": "B25/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3514,7 +3514,7 @@
               "name": "HV_C_V_047",
               "expression": "B26/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3522,7 +3522,7 @@
               "name": "HV_C_V_048",
               "expression": "B27/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3530,7 +3530,7 @@
               "name": "HV_C_V_049",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3538,7 +3538,7 @@
               "name": "HV_C_V_050",
               "expression": "B29/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3546,7 +3546,7 @@
               "name": "HV_C_V_051",
               "expression": "B30/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3554,7 +3554,7 @@
               "name": "HV_C_V_052",
               "expression": "B31/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3562,7 +3562,7 @@
               "name": "HV_C_V_053",
               "expression": "B33/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3570,7 +3570,7 @@
               "name": "HV_C_V_054",
               "expression": "B34/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3578,7 +3578,7 @@
               "name": "HV_C_V_055",
               "expression": "B35/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3586,7 +3586,7 @@
               "name": "HV_C_V_056",
               "expression": "B36/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3594,7 +3594,7 @@
               "name": "HV_C_V_057",
               "expression": "B37/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3602,7 +3602,7 @@
               "name": "HV_C_V_058",
               "expression": "B38/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3610,7 +3610,7 @@
               "name": "HV_C_V_059",
               "expression": "B39/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3618,7 +3618,7 @@
               "name": "HV_C_V_060",
               "expression": "B41/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3626,7 +3626,7 @@
               "name": "HV_C_V_061",
               "expression": "B42/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3634,7 +3634,7 @@
               "name": "HV_C_V_062",
               "expression": "B43/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3642,7 +3642,7 @@
               "name": "HV_C_V_063",
               "expression": "B44/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3650,7 +3650,7 @@
               "name": "HV_C_V_064",
               "expression": "B45/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             }
@@ -3664,7 +3664,7 @@
               "name": "HV_C_V_065",
               "expression": "B10/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3672,7 +3672,7 @@
               "name": "HV_C_V_066",
               "expression": "B11/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3680,7 +3680,7 @@
               "name": "HV_C_V_067",
               "expression": "B12/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3688,7 +3688,7 @@
               "name": "HV_C_V_068",
               "expression": "B13/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3696,7 +3696,7 @@
               "name": "HV_C_V_069",
               "expression": "B14/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3704,7 +3704,7 @@
               "name": "HV_C_V_070",
               "expression": "B15/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3712,7 +3712,7 @@
               "name": "HV_C_V_071",
               "expression": "B17/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3720,7 +3720,7 @@
               "name": "HV_C_V_072",
               "expression": "B18/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3728,7 +3728,7 @@
               "name": "HV_C_V_073",
               "expression": "B19/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3736,7 +3736,7 @@
               "name": "HV_C_V_074",
               "expression": "B20/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3744,7 +3744,7 @@
               "name": "HV_C_V_075",
               "expression": "B21/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3752,7 +3752,7 @@
               "name": "HV_C_V_076",
               "expression": "B22/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3760,7 +3760,7 @@
               "name": "HV_C_V_077",
               "expression": "B23/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3768,7 +3768,7 @@
               "name": "HV_C_V_078",
               "expression": "B25/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3776,7 +3776,7 @@
               "name": "HV_C_V_079",
               "expression": "B26/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3784,7 +3784,7 @@
               "name": "HV_C_V_080",
               "expression": "B27/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3792,7 +3792,7 @@
               "name": "HV_C_V_081",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3800,7 +3800,7 @@
               "name": "HV_C_V_082",
               "expression": "B29/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3808,7 +3808,7 @@
               "name": "HV_C_V_083",
               "expression": "B30/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3816,7 +3816,7 @@
               "name": "HV_C_V_084",
               "expression": "B31/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3824,7 +3824,7 @@
               "name": "HV_C_V_085",
               "expression": "B33/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3832,7 +3832,7 @@
               "name": "HV_C_V_086",
               "expression": "B34/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3840,7 +3840,7 @@
               "name": "HV_C_V_087",
               "expression": "B35/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3848,7 +3848,7 @@
               "name": "HV_C_V_088",
               "expression": "B36/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3856,7 +3856,7 @@
               "name": "HV_C_V_089",
               "expression": "B37/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3864,7 +3864,7 @@
               "name": "HV_C_V_090",
               "expression": "B38/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3872,7 +3872,7 @@
               "name": "HV_C_V_091",
               "expression": "B39/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3880,7 +3880,7 @@
               "name": "HV_C_V_092",
               "expression": "B41/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3888,7 +3888,7 @@
               "name": "HV_C_V_093",
               "expression": "B42/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3896,7 +3896,7 @@
               "name": "HV_C_V_094",
               "expression": "B43/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3904,7 +3904,7 @@
               "name": "HV_C_V_095",
               "expression": "B44/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3912,7 +3912,7 @@
               "name": "HV_C_V_096",
               "expression": "B45/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             }
@@ -3926,7 +3926,7 @@
               "name": "HV_C_V_097",
               "expression": "B10/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3934,7 +3934,7 @@
               "name": "HV_C_V_098",
               "expression": "B11/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3942,7 +3942,7 @@
               "name": "HV_C_V_099",
               "expression": "B12/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3950,7 +3950,7 @@
               "name": "HV_C_V_100",
               "expression": "B13/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3958,7 +3958,7 @@
               "name": "HV_C_V_101",
               "expression": "B14/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3966,7 +3966,7 @@
               "name": "HV_C_V_102",
               "expression": "B15/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3974,7 +3974,7 @@
               "name": "HV_C_V_103",
               "expression": "B17/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3982,7 +3982,7 @@
               "name": "HV_C_V_104",
               "expression": "B18/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3990,7 +3990,7 @@
               "name": "HV_C_V_105",
               "expression": "B19/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -3998,7 +3998,7 @@
               "name": "HV_C_V_106",
               "expression": "B20/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4006,7 +4006,7 @@
               "name": "HV_C_V_107",
               "expression": "B21/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4014,7 +4014,7 @@
               "name": "HV_C_V_108",
               "expression": "B22/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4022,7 +4022,7 @@
               "name": "HV_C_V_109",
               "expression": "B23/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4030,7 +4030,7 @@
               "name": "HV_C_V_110",
               "expression": "B25/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4038,7 +4038,7 @@
               "name": "HV_C_V_111",
               "expression": "B26/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4046,7 +4046,7 @@
               "name": "HV_C_V_112",
               "expression": "B27/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4054,7 +4054,7 @@
               "name": "HV_C_V_113",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4062,7 +4062,7 @@
               "name": "HV_C_V_114",
               "expression": "B29/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4070,7 +4070,7 @@
               "name": "HV_C_V_115",
               "expression": "B30/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4078,7 +4078,7 @@
               "name": "HV_C_V_116",
               "expression": "B31/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4086,7 +4086,7 @@
               "name": "HV_C_V_117",
               "expression": "B33/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4094,7 +4094,7 @@
               "name": "HV_C_V_118",
               "expression": "B34/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4102,7 +4102,7 @@
               "name": "HV_C_V_119",
               "expression": "B35/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4110,7 +4110,7 @@
               "name": "HV_C_V_120",
               "expression": "B36/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4118,7 +4118,7 @@
               "name": "HV_C_V_121",
               "expression": "B37/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4126,7 +4126,7 @@
               "name": "HV_C_V_122",
               "expression": "B38/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4134,7 +4134,7 @@
               "name": "HV_C_V_123",
               "expression": "B39/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4142,7 +4142,7 @@
               "name": "HV_C_V_124",
               "expression": "B41/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4150,7 +4150,7 @@
               "name": "HV_C_V_125",
               "expression": "B42/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4158,7 +4158,7 @@
               "name": "HV_C_V_126",
               "expression": "B43/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4166,7 +4166,7 @@
               "name": "HV_C_V_127",
               "expression": "B44/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4174,7 +4174,7 @@
               "name": "HV_C_V_128",
               "expression": "B45/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             }
@@ -4188,7 +4188,7 @@
               "name": "HV_C_V_129",
               "expression": "B10/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4196,7 +4196,7 @@
               "name": "HV_C_V_130",
               "expression": "B11/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4204,7 +4204,7 @@
               "name": "HV_C_V_131",
               "expression": "B12/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4212,7 +4212,7 @@
               "name": "HV_C_V_132",
               "expression": "B13/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4220,7 +4220,7 @@
               "name": "HV_C_V_133",
               "expression": "B14/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4228,7 +4228,7 @@
               "name": "HV_C_V_134",
               "expression": "B15/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4236,7 +4236,7 @@
               "name": "HV_C_V_135",
               "expression": "B17/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4244,7 +4244,7 @@
               "name": "HV_C_V_136",
               "expression": "B18/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4252,7 +4252,7 @@
               "name": "HV_C_V_137",
               "expression": "B19/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4260,7 +4260,7 @@
               "name": "HV_C_V_138",
               "expression": "B20/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4268,7 +4268,7 @@
               "name": "HV_C_V_139",
               "expression": "B21/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4276,7 +4276,7 @@
               "name": "HV_C_V_140",
               "expression": "B22/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4284,7 +4284,7 @@
               "name": "HV_C_V_141",
               "expression": "B23/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4292,7 +4292,7 @@
               "name": "HV_C_V_142",
               "expression": "B25/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4300,7 +4300,7 @@
               "name": "HV_C_V_143",
               "expression": "B26/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4308,7 +4308,7 @@
               "name": "HV_C_V_144",
               "expression": "B27/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4316,7 +4316,7 @@
               "name": "HV_C_V_145",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4324,7 +4324,7 @@
               "name": "HV_C_V_146",
               "expression": "B29/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4332,7 +4332,7 @@
               "name": "HV_C_V_147",
               "expression": "B30/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4340,7 +4340,7 @@
               "name": "HV_C_V_148",
               "expression": "B31/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4348,7 +4348,7 @@
               "name": "HV_C_V_149",
               "expression": "B33/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4356,7 +4356,7 @@
               "name": "HV_C_V_150",
               "expression": "B34/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4364,7 +4364,7 @@
               "name": "HV_C_V_151",
               "expression": "B35/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4372,7 +4372,7 @@
               "name": "HV_C_V_152",
               "expression": "B36/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4380,7 +4380,7 @@
               "name": "HV_C_V_153",
               "expression": "B37/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4388,7 +4388,7 @@
               "name": "HV_C_V_154",
               "expression": "B38/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4396,7 +4396,7 @@
               "name": "HV_C_V_155",
               "expression": "B39/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4404,7 +4404,7 @@
               "name": "HV_C_V_156",
               "expression": "B41/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4412,7 +4412,7 @@
               "name": "HV_C_V_157",
               "expression": "B42/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4420,7 +4420,7 @@
               "name": "HV_C_V_168",
               "expression": "B43/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4428,7 +4428,7 @@
               "name": "HV_C_V_159",
               "expression": "B44/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4436,7 +4436,7 @@
               "name": "HV_C_V_160",
               "expression": "B45/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             }
@@ -4450,7 +4450,7 @@
               "name": "HV_C_V_161",
               "expression": "B10/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4458,7 +4458,7 @@
               "name": "HV_C_V_162",
               "expression": "B11/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4466,7 +4466,7 @@
               "name": "HV_C_V_163",
               "expression": "B12/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4474,7 +4474,7 @@
               "name": "HV_C_V_164",
               "expression": "B13/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4482,7 +4482,7 @@
               "name": "HV_C_V_165",
               "expression": "B14/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4490,7 +4490,7 @@
               "name": "HV_C_V_166",
               "expression": "B15/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4498,7 +4498,7 @@
               "name": "HV_C_V_167",
               "expression": "B17/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4506,7 +4506,7 @@
               "name": "HV_C_V_168",
               "expression": "B18/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4514,7 +4514,7 @@
               "name": "HV_C_V_169",
               "expression": "B19/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4522,7 +4522,7 @@
               "name": "HV_C_V_170",
               "expression": "B20/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4530,7 +4530,7 @@
               "name": "HV_C_V_171",
               "expression": "B21/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4538,7 +4538,7 @@
               "name": "HV_C_V_172",
               "expression": "B22/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4546,7 +4546,7 @@
               "name": "HV_C_V_173",
               "expression": "B23/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4554,7 +4554,7 @@
               "name": "HV_C_V_174",
               "expression": "B25/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4562,7 +4562,7 @@
               "name": "HV_C_V_175",
               "expression": "B26/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4570,7 +4570,7 @@
               "name": "HV_C_V_176",
               "expression": "B27/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4578,7 +4578,7 @@
               "name": "HV_C_V_177",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4586,7 +4586,7 @@
               "name": "HV_C_V_178",
               "expression": "B29/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4594,7 +4594,7 @@
               "name": "HV_C_V_179",
               "expression": "B30/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -4602,7 +4602,7 @@
               "name": "HV_C_V_180",
               "expression": "B31/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             }
@@ -4666,7 +4666,7 @@
               "name": "HV_C_DIFF",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "4"
             },
@@ -4770,7 +4770,7 @@
               "name": "HV_KWH_R",
               "expression": "((B37 << 8) + B38) *2",
               "unit": "Wh",
-              "class": "battery",
+              "class": "energy",
               "min": "0",
               "max": "77000"
             },
@@ -4810,7 +4810,7 @@
               "name": "LV_V",
               "expression": "B38*0.1",
               "unit": "V",
-              "class": "battery"
+              "class": "voltage"
             },
             {
               "name": "HV_T_MAX",
@@ -4891,8 +4891,8 @@
             {
               "name": "KWH_CHARGED",
               "expression": "((B49<<24)+(B50<<16)+(B51<<8)+B52)/10",
-              "unit": "kwh",
-              "class": "battery",
+              "unit": "kWh",
+              "class": "energy",
               "min": "0",
               "max": "1000000"
             },
@@ -4900,7 +4900,7 @@
               "name": "KWH_DISCHARGED",
               "expression": "((B53<<24)+(B54<<16)+(B55<<8)+B57)/10",
               "unit": "kWh",
-              "class": "none",
+              "class": "energy",
               "min": "0",
               "max": "1000000"
             },
@@ -4923,7 +4923,7 @@
               "name": "CAPACITOR",
               "expression": "((B63<<8)+B35)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "840"
             },
@@ -5135,7 +5135,7 @@
               "name": "HV_C_V_001",
               "expression": "B10/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5143,7 +5143,7 @@
               "name": "HV_C_V_002",
               "expression": "B11/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5151,7 +5151,7 @@
               "name": "HV_C_V_003",
               "expression": "B12/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5159,7 +5159,7 @@
               "name": "HV_C_V_004",
               "expression": "B13/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5167,7 +5167,7 @@
               "name": "HV_C_V_005",
               "expression": "B14/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5175,7 +5175,7 @@
               "name": "HV_C_V_006",
               "expression": "B15/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5183,7 +5183,7 @@
               "name": "HV_C_V_007",
               "expression": "B17/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5191,7 +5191,7 @@
               "name": "HV_C_V_008",
               "expression": "B18/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5199,7 +5199,7 @@
               "name": "HV_C_V_009",
               "expression": "B19/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5207,7 +5207,7 @@
               "name": "HV_C_V_010",
               "expression": "B20/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5215,7 +5215,7 @@
               "name": "HV_C_V_011",
               "expression": "B21/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5223,7 +5223,7 @@
               "name": "HV_C_V_012",
               "expression": "B22/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5231,7 +5231,7 @@
               "name": "HV_C_V_013",
               "expression": "B23/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5239,7 +5239,7 @@
               "name": "HV_C_V_014",
               "expression": "B25/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5247,7 +5247,7 @@
               "name": "HV_C_V_015",
               "expression": "B26/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5255,7 +5255,7 @@
               "name": "HV_C_V_016",
               "expression": "B27/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5263,7 +5263,7 @@
               "name": "HV_C_V_017",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5271,7 +5271,7 @@
               "name": "HV_C_V_018",
               "expression": "B29/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5279,7 +5279,7 @@
               "name": "HV_C_V_019",
               "expression": "B30/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5287,7 +5287,7 @@
               "name": "HV_C_V_020",
               "expression": "B31/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5295,7 +5295,7 @@
               "name": "HV_C_V_021",
               "expression": "B33/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5303,7 +5303,7 @@
               "name": "HV_C_V_022",
               "expression": "B34/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5311,7 +5311,7 @@
               "name": "HV_C_V_023",
               "expression": "B35/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5319,7 +5319,7 @@
               "name": "HV_C_V_024",
               "expression": "B36/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5327,7 +5327,7 @@
               "name": "HV_C_V_025",
               "expression": "B37/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5335,7 +5335,7 @@
               "name": "HV_C_V_026",
               "expression": "B38/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5343,7 +5343,7 @@
               "name": "HV_C_V_027",
               "expression": "B39/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5351,7 +5351,7 @@
               "name": "HV_C_V_028",
               "expression": "B41/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5359,7 +5359,7 @@
               "name": "HV_C_V_029",
               "expression": "B42/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5367,7 +5367,7 @@
               "name": "HV_C_V_030",
               "expression": "B43/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5375,7 +5375,7 @@
               "name": "HV_C_V_031",
               "expression": "B44/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5383,7 +5383,7 @@
               "name": "HV_C_V_032",
               "expression": "B45/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             }
@@ -5397,7 +5397,7 @@
               "name": "HV_C_V_033",
               "expression": "B10/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5405,7 +5405,7 @@
               "name": "HV_C_V_034",
               "expression": "B11/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5413,7 +5413,7 @@
               "name": "HV_C_V_035",
               "expression": "B12/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5421,7 +5421,7 @@
               "name": "HV_C_V_036",
               "expression": "B13/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5429,7 +5429,7 @@
               "name": "HV_C_V_037",
               "expression": "B14/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5437,7 +5437,7 @@
               "name": "HV_C_V_038",
               "expression": "B15/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5445,7 +5445,7 @@
               "name": "HV_C_V_039",
               "expression": "B17/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5453,7 +5453,7 @@
               "name": "HV_C_V_040",
               "expression": "B18/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5461,7 +5461,7 @@
               "name": "HV_C_V_041",
               "expression": "B19/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5469,7 +5469,7 @@
               "name": "HV_C_V_042",
               "expression": "B20/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5477,7 +5477,7 @@
               "name": "HV_C_V_043",
               "expression": "B21/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5485,7 +5485,7 @@
               "name": "HV_C_V_044",
               "expression": "B22/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5493,7 +5493,7 @@
               "name": "HV_C_V_045",
               "expression": "B23/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5501,7 +5501,7 @@
               "name": "HV_C_V_046",
               "expression": "B25/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5509,7 +5509,7 @@
               "name": "HV_C_V_047",
               "expression": "B26/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5517,7 +5517,7 @@
               "name": "HV_C_V_048",
               "expression": "B27/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5525,7 +5525,7 @@
               "name": "HV_C_V_049",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5533,7 +5533,7 @@
               "name": "HV_C_V_050",
               "expression": "B29/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5541,7 +5541,7 @@
               "name": "HV_C_V_051",
               "expression": "B30/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5549,7 +5549,7 @@
               "name": "HV_C_V_052",
               "expression": "B31/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5557,7 +5557,7 @@
               "name": "HV_C_V_053",
               "expression": "B33/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5565,7 +5565,7 @@
               "name": "HV_C_V_054",
               "expression": "B34/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5573,7 +5573,7 @@
               "name": "HV_C_V_055",
               "expression": "B35/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5581,7 +5581,7 @@
               "name": "HV_C_V_056",
               "expression": "B36/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5589,7 +5589,7 @@
               "name": "HV_C_V_057",
               "expression": "B37/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5597,7 +5597,7 @@
               "name": "HV_C_V_058",
               "expression": "B38/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5605,7 +5605,7 @@
               "name": "HV_C_V_059",
               "expression": "B39/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5613,7 +5613,7 @@
               "name": "HV_C_V_060",
               "expression": "B41/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5621,7 +5621,7 @@
               "name": "HV_C_V_061",
               "expression": "B42/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5629,7 +5629,7 @@
               "name": "HV_C_V_062",
               "expression": "B43/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5637,7 +5637,7 @@
               "name": "HV_C_V_063",
               "expression": "B44/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5645,7 +5645,7 @@
               "name": "HV_C_V_064",
               "expression": "B45/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             }
@@ -5659,7 +5659,7 @@
               "name": "HV_C_V_065",
               "expression": "B10/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5667,7 +5667,7 @@
               "name": "HV_C_V_066",
               "expression": "B11/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5675,7 +5675,7 @@
               "name": "HV_C_V_067",
               "expression": "B12/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5683,7 +5683,7 @@
               "name": "HV_C_V_068",
               "expression": "B13/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5691,7 +5691,7 @@
               "name": "HV_C_V_069",
               "expression": "B14/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5699,7 +5699,7 @@
               "name": "HV_C_V_070",
               "expression": "B15/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5707,7 +5707,7 @@
               "name": "HV_C_V_071",
               "expression": "B17/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5715,7 +5715,7 @@
               "name": "HV_C_V_072",
               "expression": "B18/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5723,7 +5723,7 @@
               "name": "HV_C_V_073",
               "expression": "B19/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5731,7 +5731,7 @@
               "name": "HV_C_V_074",
               "expression": "B20/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5739,7 +5739,7 @@
               "name": "HV_C_V_075",
               "expression": "B21/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5747,7 +5747,7 @@
               "name": "HV_C_V_076",
               "expression": "B22/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5755,7 +5755,7 @@
               "name": "HV_C_V_077",
               "expression": "B23/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5763,7 +5763,7 @@
               "name": "HV_C_V_078",
               "expression": "B25/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5771,7 +5771,7 @@
               "name": "HV_C_V_079",
               "expression": "B26/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5779,7 +5779,7 @@
               "name": "HV_C_V_080",
               "expression": "B27/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5787,7 +5787,7 @@
               "name": "HV_C_V_081",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5795,7 +5795,7 @@
               "name": "HV_C_V_082",
               "expression": "B29/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5803,7 +5803,7 @@
               "name": "HV_C_V_083",
               "expression": "B30/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5811,7 +5811,7 @@
               "name": "HV_C_V_084",
               "expression": "B31/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5819,7 +5819,7 @@
               "name": "HV_C_V_085",
               "expression": "B33/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5827,7 +5827,7 @@
               "name": "HV_C_V_086",
               "expression": "B34/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5835,7 +5835,7 @@
               "name": "HV_C_V_087",
               "expression": "B35/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5843,7 +5843,7 @@
               "name": "HV_C_V_088",
               "expression": "B36/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5851,7 +5851,7 @@
               "name": "HV_C_V_089",
               "expression": "B37/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5859,7 +5859,7 @@
               "name": "HV_C_V_090",
               "expression": "B38/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5867,7 +5867,7 @@
               "name": "HV_C_V_091",
               "expression": "B39/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5875,7 +5875,7 @@
               "name": "HV_C_V_092",
               "expression": "B41/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5883,7 +5883,7 @@
               "name": "HV_C_V_093",
               "expression": "B42/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5891,7 +5891,7 @@
               "name": "HV_C_V_094",
               "expression": "B43/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5899,7 +5899,7 @@
               "name": "HV_C_V_095",
               "expression": "B44/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5907,7 +5907,7 @@
               "name": "HV_C_V_096",
               "expression": "B45/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             }
@@ -5921,7 +5921,7 @@
               "name": "HV_C_V_097",
               "expression": "B10/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5929,7 +5929,7 @@
               "name": "HV_C_V_098",
               "expression": "B11/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5937,7 +5937,7 @@
               "name": "HV_C_V_099",
               "expression": "B12/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5945,7 +5945,7 @@
               "name": "HV_C_V_100",
               "expression": "B13/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5953,7 +5953,7 @@
               "name": "HV_C_V_101",
               "expression": "B14/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5961,7 +5961,7 @@
               "name": "HV_C_V_102",
               "expression": "B15/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5969,7 +5969,7 @@
               "name": "HV_C_V_103",
               "expression": "B17/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5977,7 +5977,7 @@
               "name": "HV_C_V_104",
               "expression": "B18/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5985,7 +5985,7 @@
               "name": "HV_C_V_105",
               "expression": "B19/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -5993,7 +5993,7 @@
               "name": "HV_C_V_106",
               "expression": "B20/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6001,7 +6001,7 @@
               "name": "HV_C_V_107",
               "expression": "B21/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6009,7 +6009,7 @@
               "name": "HV_C_V_108",
               "expression": "B22/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6017,7 +6017,7 @@
               "name": "HV_C_V_109",
               "expression": "B23/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6025,7 +6025,7 @@
               "name": "HV_C_V_110",
               "expression": "B25/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6033,7 +6033,7 @@
               "name": "HV_C_V_111",
               "expression": "B26/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6041,7 +6041,7 @@
               "name": "HV_C_V_112",
               "expression": "B27/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6049,7 +6049,7 @@
               "name": "HV_C_V_113",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6057,7 +6057,7 @@
               "name": "HV_C_V_114",
               "expression": "B29/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6065,7 +6065,7 @@
               "name": "HV_C_V_115",
               "expression": "B30/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6073,7 +6073,7 @@
               "name": "HV_C_V_116",
               "expression": "B31/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6081,7 +6081,7 @@
               "name": "HV_C_V_117",
               "expression": "B33/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6089,7 +6089,7 @@
               "name": "HV_C_V_118",
               "expression": "B34/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6097,7 +6097,7 @@
               "name": "HV_C_V_119",
               "expression": "B35/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6105,7 +6105,7 @@
               "name": "HV_C_V_120",
               "expression": "B36/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6113,7 +6113,7 @@
               "name": "HV_C_V_121",
               "expression": "B37/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6121,7 +6121,7 @@
               "name": "HV_C_V_122",
               "expression": "B38/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6129,7 +6129,7 @@
               "name": "HV_C_V_123",
               "expression": "B39/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6137,7 +6137,7 @@
               "name": "HV_C_V_124",
               "expression": "B41/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6145,7 +6145,7 @@
               "name": "HV_C_V_125",
               "expression": "B42/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6153,7 +6153,7 @@
               "name": "HV_C_V_126",
               "expression": "B43/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6161,7 +6161,7 @@
               "name": "HV_C_V_127",
               "expression": "B44/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6169,7 +6169,7 @@
               "name": "HV_C_V_128",
               "expression": "B45/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             }
@@ -6183,7 +6183,7 @@
               "name": "HV_C_V_129",
               "expression": "B10/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6191,7 +6191,7 @@
               "name": "HV_C_V_130",
               "expression": "B11/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6199,7 +6199,7 @@
               "name": "HV_C_V_131",
               "expression": "B12/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6207,7 +6207,7 @@
               "name": "HV_C_V_132",
               "expression": "B13/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6215,7 +6215,7 @@
               "name": "HV_C_V_133",
               "expression": "B14/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6223,7 +6223,7 @@
               "name": "HV_C_V_134",
               "expression": "B15/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6231,7 +6231,7 @@
               "name": "HV_C_V_135",
               "expression": "B17/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6239,7 +6239,7 @@
               "name": "HV_C_V_136",
               "expression": "B18/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6247,7 +6247,7 @@
               "name": "HV_C_V_137",
               "expression": "B19/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6255,7 +6255,7 @@
               "name": "HV_C_V_138",
               "expression": "B20/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6263,7 +6263,7 @@
               "name": "HV_C_V_139",
               "expression": "B21/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6271,7 +6271,7 @@
               "name": "HV_C_V_140",
               "expression": "B22/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6279,7 +6279,7 @@
               "name": "HV_C_V_141",
               "expression": "B23/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6287,7 +6287,7 @@
               "name": "HV_C_V_142",
               "expression": "B25/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6295,7 +6295,7 @@
               "name": "HV_C_V_143",
               "expression": "B26/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6303,7 +6303,7 @@
               "name": "HV_C_V_144",
               "expression": "B27/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6311,7 +6311,7 @@
               "name": "HV_C_V_145",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6319,7 +6319,7 @@
               "name": "HV_C_V_146",
               "expression": "B29/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6327,7 +6327,7 @@
               "name": "HV_C_V_147",
               "expression": "B30/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6335,7 +6335,7 @@
               "name": "HV_C_V_148",
               "expression": "B31/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6343,7 +6343,7 @@
               "name": "HV_C_V_149",
               "expression": "B33/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6351,7 +6351,7 @@
               "name": "HV_C_V_150",
               "expression": "B34/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6359,7 +6359,7 @@
               "name": "HV_C_V_151",
               "expression": "B35/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6367,7 +6367,7 @@
               "name": "HV_C_V_152",
               "expression": "B36/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6375,7 +6375,7 @@
               "name": "HV_C_V_153",
               "expression": "B37/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6383,7 +6383,7 @@
               "name": "HV_C_V_154",
               "expression": "B38/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6391,7 +6391,7 @@
               "name": "HV_C_V_155",
               "expression": "B39/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6399,7 +6399,7 @@
               "name": "HV_C_V_156",
               "expression": "B41/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6407,7 +6407,7 @@
               "name": "HV_C_V_157",
               "expression": "B42/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6415,7 +6415,7 @@
               "name": "HV_C_V_168",
               "expression": "B43/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6423,7 +6423,7 @@
               "name": "HV_C_V_159",
               "expression": "B44/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6431,7 +6431,7 @@
               "name": "HV_C_V_160",
               "expression": "B45/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             }
@@ -6445,7 +6445,7 @@
               "name": "HV_C_V_161",
               "expression": "B10/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6453,7 +6453,7 @@
               "name": "HV_C_V_162",
               "expression": "B11/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6461,7 +6461,7 @@
               "name": "HV_C_V_163",
               "expression": "B12/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6469,7 +6469,7 @@
               "name": "HV_C_V_164",
               "expression": "B13/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6477,7 +6477,7 @@
               "name": "HV_C_V_165",
               "expression": "B14/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6485,7 +6485,7 @@
               "name": "HV_C_V_166",
               "expression": "B15/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6493,7 +6493,7 @@
               "name": "HV_C_V_167",
               "expression": "B17/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6501,7 +6501,7 @@
               "name": "HV_C_V_168",
               "expression": "B18/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6509,7 +6509,7 @@
               "name": "HV_C_V_169",
               "expression": "B19/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6517,7 +6517,7 @@
               "name": "HV_C_V_170",
               "expression": "B20/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6525,7 +6525,7 @@
               "name": "HV_C_V_171",
               "expression": "B21/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6533,7 +6533,7 @@
               "name": "HV_C_V_172",
               "expression": "B22/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6541,7 +6541,7 @@
               "name": "HV_C_V_173",
               "expression": "B23/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6549,7 +6549,7 @@
               "name": "HV_C_V_174",
               "expression": "B25/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6557,7 +6557,7 @@
               "name": "HV_C_V_175",
               "expression": "B26/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6565,7 +6565,7 @@
               "name": "HV_C_V_176",
               "expression": "B27/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6573,7 +6573,7 @@
               "name": "HV_C_V_177",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6581,7 +6581,7 @@
               "name": "HV_C_V_178",
               "expression": "B29/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6589,7 +6589,7 @@
               "name": "HV_C_V_179",
               "expression": "B30/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -6597,7 +6597,7 @@
               "name": "HV_C_V_180",
               "expression": "B31/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             }
@@ -6729,13 +6729,13 @@
               "name": "LV_V",
               "expression": "B38*0.1",
               "unit": "V",
-              "class": "battery"
+              "class": "voltage"
             },
             {
               "name": "KWH_CHARGED",
               "expression": "([B49:B50]*65536 + [B51:B52])/10",
-              "unit": "kwh",
-              "class": "battery",
+              "unit": "kWh",
+              "class": "energy",
               "min": "0",
               "max": "1000000"
             }
@@ -6838,7 +6838,7 @@
               "name": "HV_C_DIFF",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "4"
             },
@@ -6942,7 +6942,7 @@
               "name": "HV_KWH_R",
               "expression": "((B37 << 8) + B38) *2",
               "unit": "Wh",
-              "class": "battery",
+              "class": "energy",
               "min": "0",
               "max": "77000"
             },
@@ -6982,7 +6982,7 @@
               "name": "LV_V",
               "expression": "B38*0.1",
               "unit": "V",
-              "class": "battery"
+              "class": "voltage"
             },
             {
               "name": "HV_T_MAX",
@@ -7064,7 +7064,7 @@
               "name": "KWH_DISCHARGED",
               "expression": "((B53<<24)+(B54<<16)+(B55<<8)+B57)/10",
               "unit": "kWh",
-              "class": "none",
+              "class": "energy",
               "min": "0",
               "max": "1000000"
             },
@@ -7087,7 +7087,7 @@
               "name": "CAPACITOR",
               "expression": "((B63<<8)+B35)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "840"
             },
@@ -7584,7 +7584,7 @@
               "name": "HV_C_DIFF",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "4"
             },
@@ -7688,7 +7688,7 @@
               "name": "HV_KWH_R",
               "expression": "((B37 << 8) + B38) *2",
               "unit": "Wh",
-              "class": "battery",
+              "class": "energy",
               "min": "0",
               "max": "77000"
             },
@@ -7728,7 +7728,7 @@
               "name": "LV_V",
               "expression": "B38*0.1",
               "unit": "V",
-              "class": "battery"
+              "class": "voltage"
             },
             {
               "name": "HV_T_MAX",
@@ -7809,8 +7809,8 @@
             {
               "name": "KWH_CHARGED",
               "expression": "((B49<<24)+(B50<<16)+(B51<<8)+B52)/10",
-              "unit": "kwh",
-              "class": "battery",
+              "unit": "kWh",
+              "class": "energy",
               "min": "0",
               "max": "1000000"
             },
@@ -7818,7 +7818,7 @@
               "name": "KWH_DISCHARGED",
               "expression": "((B53<<24)+(B54<<16)+(B55<<8)+B57)/10",
               "unit": "kWh",
-              "class": "none",
+              "class": "energy",
               "min": "0",
               "max": "1000000"
             },
@@ -7841,7 +7841,7 @@
               "name": "CAPACITOR",
               "expression": "((B63<<8)+B35)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "840"
             },
@@ -8103,7 +8103,7 @@
               "name": "HV_C_DIFF",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "4"
             },
@@ -8207,7 +8207,7 @@
               "name": "HV_KWH_R",
               "expression": "((B37 << 8) + B38) *2",
               "unit": "Wh",
-              "class": "battery",
+              "class": "energy",
               "min": "0",
               "max": "77000"
             },
@@ -8247,7 +8247,7 @@
               "name": "LV_V",
               "expression": "B38*0.1",
               "unit": "V",
-              "class": "battery"
+              "class": "voltage"
             },
             {
               "name": "HV_T_MAX",
@@ -8328,8 +8328,8 @@
             {
               "name": "KWH_CHARGED",
               "expression": "((B49<<24)+(B50<<16)+(B51<<8)+B52)/10",
-              "unit": "kwh",
-              "class": "battery",
+              "unit": "kWh",
+              "class": "energy",
               "min": "0",
               "max": "1000000"
             },
@@ -8337,7 +8337,7 @@
               "name": "KWH_DISCHARGED",
               "expression": "((B53<<24)+(B54<<16)+(B55<<8)+B57)/10",
               "unit": "kWh",
-              "class": "none",
+              "class": "energy",
               "min": "0",
               "max": "1000000"
             },
@@ -8360,7 +8360,7 @@
               "name": "CAPACITOR",
               "expression": "((B63<<8)+B35)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "840"
             },
@@ -8572,7 +8572,7 @@
               "name": "HV_C_V_001",
               "expression": "B10/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8580,7 +8580,7 @@
               "name": "HV_C_V_002",
               "expression": "B11/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8588,7 +8588,7 @@
               "name": "HV_C_V_003",
               "expression": "B12/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8596,7 +8596,7 @@
               "name": "HV_C_V_004",
               "expression": "B13/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8604,7 +8604,7 @@
               "name": "HV_C_V_005",
               "expression": "B14/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8612,7 +8612,7 @@
               "name": "HV_C_V_006",
               "expression": "B15/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8620,7 +8620,7 @@
               "name": "HV_C_V_007",
               "expression": "B17/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8628,7 +8628,7 @@
               "name": "HV_C_V_008",
               "expression": "B18/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8636,7 +8636,7 @@
               "name": "HV_C_V_009",
               "expression": "B19/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8644,7 +8644,7 @@
               "name": "HV_C_V_010",
               "expression": "B20/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8652,7 +8652,7 @@
               "name": "HV_C_V_011",
               "expression": "B21/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8660,7 +8660,7 @@
               "name": "HV_C_V_012",
               "expression": "B22/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8668,7 +8668,7 @@
               "name": "HV_C_V_013",
               "expression": "B23/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8676,7 +8676,7 @@
               "name": "HV_C_V_014",
               "expression": "B25/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8684,7 +8684,7 @@
               "name": "HV_C_V_015",
               "expression": "B26/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8692,7 +8692,7 @@
               "name": "HV_C_V_016",
               "expression": "B27/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8700,7 +8700,7 @@
               "name": "HV_C_V_017",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8708,7 +8708,7 @@
               "name": "HV_C_V_018",
               "expression": "B29/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8716,7 +8716,7 @@
               "name": "HV_C_V_019",
               "expression": "B30/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8724,7 +8724,7 @@
               "name": "HV_C_V_020",
               "expression": "B31/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8732,7 +8732,7 @@
               "name": "HV_C_V_021",
               "expression": "B33/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8740,7 +8740,7 @@
               "name": "HV_C_V_022",
               "expression": "B34/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8748,7 +8748,7 @@
               "name": "HV_C_V_023",
               "expression": "B35/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8756,7 +8756,7 @@
               "name": "HV_C_V_024",
               "expression": "B36/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8764,7 +8764,7 @@
               "name": "HV_C_V_025",
               "expression": "B37/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8772,7 +8772,7 @@
               "name": "HV_C_V_026",
               "expression": "B38/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8780,7 +8780,7 @@
               "name": "HV_C_V_027",
               "expression": "B39/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8788,7 +8788,7 @@
               "name": "HV_C_V_028",
               "expression": "B41/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8796,7 +8796,7 @@
               "name": "HV_C_V_029",
               "expression": "B42/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8804,7 +8804,7 @@
               "name": "HV_C_V_030",
               "expression": "B43/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8812,7 +8812,7 @@
               "name": "HV_C_V_031",
               "expression": "B44/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8820,7 +8820,7 @@
               "name": "HV_C_V_032",
               "expression": "B45/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             }
@@ -8834,7 +8834,7 @@
               "name": "HV_C_V_033",
               "expression": "B10/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8842,7 +8842,7 @@
               "name": "HV_C_V_034",
               "expression": "B11/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8850,7 +8850,7 @@
               "name": "HV_C_V_035",
               "expression": "B12/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8858,7 +8858,7 @@
               "name": "HV_C_V_036",
               "expression": "B13/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8866,7 +8866,7 @@
               "name": "HV_C_V_037",
               "expression": "B14/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8874,7 +8874,7 @@
               "name": "HV_C_V_038",
               "expression": "B15/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8882,7 +8882,7 @@
               "name": "HV_C_V_039",
               "expression": "B17/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8890,7 +8890,7 @@
               "name": "HV_C_V_040",
               "expression": "B18/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8898,7 +8898,7 @@
               "name": "HV_C_V_041",
               "expression": "B19/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8906,7 +8906,7 @@
               "name": "HV_C_V_042",
               "expression": "B20/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8914,7 +8914,7 @@
               "name": "HV_C_V_043",
               "expression": "B21/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8922,7 +8922,7 @@
               "name": "HV_C_V_044",
               "expression": "B22/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8930,7 +8930,7 @@
               "name": "HV_C_V_045",
               "expression": "B23/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8938,7 +8938,7 @@
               "name": "HV_C_V_046",
               "expression": "B25/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8946,7 +8946,7 @@
               "name": "HV_C_V_047",
               "expression": "B26/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8954,7 +8954,7 @@
               "name": "HV_C_V_048",
               "expression": "B27/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8962,7 +8962,7 @@
               "name": "HV_C_V_049",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8970,7 +8970,7 @@
               "name": "HV_C_V_050",
               "expression": "B29/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8978,7 +8978,7 @@
               "name": "HV_C_V_051",
               "expression": "B30/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8986,7 +8986,7 @@
               "name": "HV_C_V_052",
               "expression": "B31/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -8994,7 +8994,7 @@
               "name": "HV_C_V_053",
               "expression": "B33/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9002,7 +9002,7 @@
               "name": "HV_C_V_054",
               "expression": "B34/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9010,7 +9010,7 @@
               "name": "HV_C_V_055",
               "expression": "B35/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9018,7 +9018,7 @@
               "name": "HV_C_V_056",
               "expression": "B36/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9026,7 +9026,7 @@
               "name": "HV_C_V_057",
               "expression": "B37/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9034,7 +9034,7 @@
               "name": "HV_C_V_058",
               "expression": "B38/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9042,7 +9042,7 @@
               "name": "HV_C_V_059",
               "expression": "B39/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9050,7 +9050,7 @@
               "name": "HV_C_V_060",
               "expression": "B41/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9058,7 +9058,7 @@
               "name": "HV_C_V_061",
               "expression": "B42/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9066,7 +9066,7 @@
               "name": "HV_C_V_062",
               "expression": "B43/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9074,7 +9074,7 @@
               "name": "HV_C_V_063",
               "expression": "B44/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9082,7 +9082,7 @@
               "name": "HV_C_V_064",
               "expression": "B45/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             }
@@ -9096,7 +9096,7 @@
               "name": "HV_C_V_065",
               "expression": "B10/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9104,7 +9104,7 @@
               "name": "HV_C_V_066",
               "expression": "B11/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9112,7 +9112,7 @@
               "name": "HV_C_V_067",
               "expression": "B12/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9120,7 +9120,7 @@
               "name": "HV_C_V_068",
               "expression": "B13/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9128,7 +9128,7 @@
               "name": "HV_C_V_069",
               "expression": "B14/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9136,7 +9136,7 @@
               "name": "HV_C_V_070",
               "expression": "B15/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9144,7 +9144,7 @@
               "name": "HV_C_V_071",
               "expression": "B17/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9152,7 +9152,7 @@
               "name": "HV_C_V_072",
               "expression": "B18/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9160,7 +9160,7 @@
               "name": "HV_C_V_073",
               "expression": "B19/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9168,7 +9168,7 @@
               "name": "HV_C_V_074",
               "expression": "B20/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9176,7 +9176,7 @@
               "name": "HV_C_V_075",
               "expression": "B21/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9184,7 +9184,7 @@
               "name": "HV_C_V_076",
               "expression": "B22/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9192,7 +9192,7 @@
               "name": "HV_C_V_077",
               "expression": "B23/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9200,7 +9200,7 @@
               "name": "HV_C_V_078",
               "expression": "B25/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9208,7 +9208,7 @@
               "name": "HV_C_V_079",
               "expression": "B26/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9216,7 +9216,7 @@
               "name": "HV_C_V_080",
               "expression": "B27/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9224,7 +9224,7 @@
               "name": "HV_C_V_081",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9232,7 +9232,7 @@
               "name": "HV_C_V_082",
               "expression": "B29/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9240,7 +9240,7 @@
               "name": "HV_C_V_083",
               "expression": "B30/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9248,7 +9248,7 @@
               "name": "HV_C_V_084",
               "expression": "B31/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9256,7 +9256,7 @@
               "name": "HV_C_V_085",
               "expression": "B33/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9264,7 +9264,7 @@
               "name": "HV_C_V_086",
               "expression": "B34/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9272,7 +9272,7 @@
               "name": "HV_C_V_087",
               "expression": "B35/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9280,7 +9280,7 @@
               "name": "HV_C_V_088",
               "expression": "B36/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9288,7 +9288,7 @@
               "name": "HV_C_V_089",
               "expression": "B37/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9296,7 +9296,7 @@
               "name": "HV_C_V_090",
               "expression": "B38/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9304,7 +9304,7 @@
               "name": "HV_C_V_091",
               "expression": "B39/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9312,7 +9312,7 @@
               "name": "HV_C_V_092",
               "expression": "B41/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9320,7 +9320,7 @@
               "name": "HV_C_V_093",
               "expression": "B42/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9328,7 +9328,7 @@
               "name": "HV_C_V_094",
               "expression": "B43/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9336,7 +9336,7 @@
               "name": "HV_C_V_095",
               "expression": "B44/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9344,7 +9344,7 @@
               "name": "HV_C_V_096",
               "expression": "B45/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             }
@@ -9358,7 +9358,7 @@
               "name": "HV_C_V_097",
               "expression": "B10/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9366,7 +9366,7 @@
               "name": "HV_C_V_098",
               "expression": "B11/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9374,7 +9374,7 @@
               "name": "HV_C_V_099",
               "expression": "B12/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9382,7 +9382,7 @@
               "name": "HV_C_V_100",
               "expression": "B13/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9390,7 +9390,7 @@
               "name": "HV_C_V_101",
               "expression": "B14/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9398,7 +9398,7 @@
               "name": "HV_C_V_102",
               "expression": "B15/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9406,7 +9406,7 @@
               "name": "HV_C_V_103",
               "expression": "B17/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9414,7 +9414,7 @@
               "name": "HV_C_V_104",
               "expression": "B18/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9422,7 +9422,7 @@
               "name": "HV_C_V_105",
               "expression": "B19/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9430,7 +9430,7 @@
               "name": "HV_C_V_106",
               "expression": "B20/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9438,7 +9438,7 @@
               "name": "HV_C_V_107",
               "expression": "B21/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9446,7 +9446,7 @@
               "name": "HV_C_V_108",
               "expression": "B22/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9454,7 +9454,7 @@
               "name": "HV_C_V_109",
               "expression": "B23/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9462,7 +9462,7 @@
               "name": "HV_C_V_110",
               "expression": "B25/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9470,7 +9470,7 @@
               "name": "HV_C_V_111",
               "expression": "B26/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9478,7 +9478,7 @@
               "name": "HV_C_V_112",
               "expression": "B27/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9486,7 +9486,7 @@
               "name": "HV_C_V_113",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9494,7 +9494,7 @@
               "name": "HV_C_V_114",
               "expression": "B29/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9502,7 +9502,7 @@
               "name": "HV_C_V_115",
               "expression": "B30/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9510,7 +9510,7 @@
               "name": "HV_C_V_116",
               "expression": "B31/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9518,7 +9518,7 @@
               "name": "HV_C_V_117",
               "expression": "B33/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9526,7 +9526,7 @@
               "name": "HV_C_V_118",
               "expression": "B34/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9534,7 +9534,7 @@
               "name": "HV_C_V_119",
               "expression": "B35/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9542,7 +9542,7 @@
               "name": "HV_C_V_120",
               "expression": "B36/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9550,7 +9550,7 @@
               "name": "HV_C_V_121",
               "expression": "B37/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9558,7 +9558,7 @@
               "name": "HV_C_V_122",
               "expression": "B38/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9566,7 +9566,7 @@
               "name": "HV_C_V_123",
               "expression": "B39/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9574,7 +9574,7 @@
               "name": "HV_C_V_124",
               "expression": "B41/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9582,7 +9582,7 @@
               "name": "HV_C_V_125",
               "expression": "B42/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9590,7 +9590,7 @@
               "name": "HV_C_V_126",
               "expression": "B43/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9598,7 +9598,7 @@
               "name": "HV_C_V_127",
               "expression": "B44/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9606,7 +9606,7 @@
               "name": "HV_C_V_128",
               "expression": "B45/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             }
@@ -9620,7 +9620,7 @@
               "name": "HV_C_V_129",
               "expression": "B10/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9628,7 +9628,7 @@
               "name": "HV_C_V_130",
               "expression": "B11/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9636,7 +9636,7 @@
               "name": "HV_C_V_131",
               "expression": "B12/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9644,7 +9644,7 @@
               "name": "HV_C_V_132",
               "expression": "B13/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9652,7 +9652,7 @@
               "name": "HV_C_V_133",
               "expression": "B14/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9660,7 +9660,7 @@
               "name": "HV_C_V_134",
               "expression": "B15/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9668,7 +9668,7 @@
               "name": "HV_C_V_135",
               "expression": "B17/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9676,7 +9676,7 @@
               "name": "HV_C_V_136",
               "expression": "B18/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9684,7 +9684,7 @@
               "name": "HV_C_V_137",
               "expression": "B19/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9692,7 +9692,7 @@
               "name": "HV_C_V_138",
               "expression": "B20/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9700,7 +9700,7 @@
               "name": "HV_C_V_139",
               "expression": "B21/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9708,7 +9708,7 @@
               "name": "HV_C_V_140",
               "expression": "B22/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9716,7 +9716,7 @@
               "name": "HV_C_V_141",
               "expression": "B23/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9724,7 +9724,7 @@
               "name": "HV_C_V_142",
               "expression": "B25/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9732,7 +9732,7 @@
               "name": "HV_C_V_143",
               "expression": "B26/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9740,7 +9740,7 @@
               "name": "HV_C_V_144",
               "expression": "B27/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9748,7 +9748,7 @@
               "name": "HV_C_V_145",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9756,7 +9756,7 @@
               "name": "HV_C_V_146",
               "expression": "B29/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9764,7 +9764,7 @@
               "name": "HV_C_V_147",
               "expression": "B30/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9772,7 +9772,7 @@
               "name": "HV_C_V_148",
               "expression": "B31/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9780,7 +9780,7 @@
               "name": "HV_C_V_149",
               "expression": "B33/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9788,7 +9788,7 @@
               "name": "HV_C_V_150",
               "expression": "B34/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9796,7 +9796,7 @@
               "name": "HV_C_V_151",
               "expression": "B35/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9804,7 +9804,7 @@
               "name": "HV_C_V_152",
               "expression": "B36/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9812,7 +9812,7 @@
               "name": "HV_C_V_153",
               "expression": "B37/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9820,7 +9820,7 @@
               "name": "HV_C_V_154",
               "expression": "B38/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9828,7 +9828,7 @@
               "name": "HV_C_V_155",
               "expression": "B39/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9836,7 +9836,7 @@
               "name": "HV_C_V_156",
               "expression": "B41/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9844,7 +9844,7 @@
               "name": "HV_C_V_157",
               "expression": "B42/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9852,7 +9852,7 @@
               "name": "HV_C_V_168",
               "expression": "B43/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9860,7 +9860,7 @@
               "name": "HV_C_V_159",
               "expression": "B44/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9868,7 +9868,7 @@
               "name": "HV_C_V_160",
               "expression": "B45/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             }
@@ -9882,7 +9882,7 @@
               "name": "HV_C_V_161",
               "expression": "B10/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9890,7 +9890,7 @@
               "name": "HV_C_V_162",
               "expression": "B11/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9898,7 +9898,7 @@
               "name": "HV_C_V_163",
               "expression": "B12/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9906,7 +9906,7 @@
               "name": "HV_C_V_164",
               "expression": "B13/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9914,7 +9914,7 @@
               "name": "HV_C_V_165",
               "expression": "B14/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9922,7 +9922,7 @@
               "name": "HV_C_V_166",
               "expression": "B15/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9930,7 +9930,7 @@
               "name": "HV_C_V_167",
               "expression": "B17/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9938,7 +9938,7 @@
               "name": "HV_C_V_168",
               "expression": "B18/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9946,7 +9946,7 @@
               "name": "HV_C_V_169",
               "expression": "B19/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9954,7 +9954,7 @@
               "name": "HV_C_V_170",
               "expression": "B20/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9962,7 +9962,7 @@
               "name": "HV_C_V_171",
               "expression": "B21/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9970,7 +9970,7 @@
               "name": "HV_C_V_172",
               "expression": "B22/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9978,7 +9978,7 @@
               "name": "HV_C_V_173",
               "expression": "B23/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9986,7 +9986,7 @@
               "name": "HV_C_V_174",
               "expression": "B25/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -9994,7 +9994,7 @@
               "name": "HV_C_V_175",
               "expression": "B26/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -10002,7 +10002,7 @@
               "name": "HV_C_V_176",
               "expression": "B27/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -10010,7 +10010,7 @@
               "name": "HV_C_V_177",
               "expression": "B28/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -10018,7 +10018,7 @@
               "name": "HV_C_V_178",
               "expression": "B29/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -10026,7 +10026,7 @@
               "name": "HV_C_V_179",
               "expression": "B30/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -10034,7 +10034,7 @@
               "name": "HV_C_V_180",
               "expression": "B31/50",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             }
@@ -10165,13 +10165,13 @@
               "name": "LV_V",
               "expression": "B38*0.1",
               "unit": "V",
-              "class": "battery"
+              "class": "voltage"
             },
             {
               "name": "KWH_CHARGED",
               "expression": "([B49:B50]*65536 + [B51:B52])/10",
-              "unit": "kwh",
-              "class": "battery",
+              "unit": "kWh",
+              "class": "energy",
               "min": "0",
               "max": "1000000"
             }
@@ -10392,7 +10392,7 @@
               "name": "LV_V",
               "expression": "B38*0.1",
               "unit": "V",
-              "class": "battery"
+              "class": "voltage"
             }
           ]
         },
@@ -10799,7 +10799,7 @@
               "name": "HV_CAPACITY_KWH",
               "expression": "((B4*256)+B5)*0.0032",
               "unit": "kWh",
-              "class": "none"
+              "class": "energy"
             }
           ]
         },
@@ -10825,7 +10825,7 @@
               "name": "AC_C_C",
               "expression": "B4*.2",
               "unit": "A",
-              "class": "battery"
+              "class": "current"
             }
           ]
         },
@@ -10837,7 +10837,7 @@
               "name": "AC_C_V",
               "expression": "B4*2",
               "unit": "V",
-              "class": "battery"
+              "class": "voltage"
             }
           ]
         },
@@ -11133,8 +11133,8 @@
             {
               "name": "KWH_CHARGED",
               "expression": "B5",
-              "unit": "kwh",
-              "class": "battery",
+              "unit": "kWh",
+              "class": "energy",
               "min": "0",
               "max": "1000000"
             }
@@ -11246,7 +11246,7 @@
               "name": "HV_AV",
               "expression": "[B4:B5] * 0.025",
               "unit": "kW",
-              "class": "battery"
+              "class": "power"
             }
           ]
         },
@@ -11279,7 +11279,7 @@
               "name": "LV_V",
               "expression": "[B4:B5] * 0.01",
               "unit": "V",
-              "class": "battery"
+              "class": "voltage"
             }
           ]
         },
@@ -11303,7 +11303,7 @@
               "name": "HV_CAPACITY_R",
               "expression": "[B4:B6] * 0.001",
               "unit": "kWh",
-              "class": "none"
+              "class": "energy"
             }
           ]
         },
@@ -11313,8 +11313,8 @@
             {
               "name": "KWH_CHARGED",
               "expression": "[B5:B8] * 0.001",
-              "unit": "kwh",
-              "class": "battery",
+              "unit": "kWh",
+              "class": "energy",
               "min": "0",
               "max": "1000000"
             }
@@ -11327,7 +11327,7 @@
               "name": "AC_C_C",
               "expression": "[B4:B5] * 0.1",
               "unit": "A",
-              "class": "battery"
+              "class": "current"
             }
           ]
         },
@@ -11338,7 +11338,7 @@
               "name": "AC_C_V",
               "expression": "[B4:B5] * 0.5",
               "unit": "V",
-              "class": "battery"
+              "class": "voltage"
             }
           ]
         }
@@ -11505,7 +11505,7 @@
               "name": "LV_V",
               "expression": "[B4:B5]*0.01",
               "unit": "V",
-              "class": "battery"
+              "class": "voltage"
             }
           ]
         },
@@ -11576,7 +11576,7 @@
               "name": "HV_AV",
               "expression": "[B4:B5]*0.005",
               "unit": "kW",
-              "class": "battery"
+              "class": "power"
             }
           ]
         },
@@ -11778,7 +11778,7 @@
               "name": "AC_C_C",
               "expression": "(([B4:B7] * 10) / 10000) - 2000",
               "unit": "A",
-              "class": "battery"
+              "class": "current"
             }
           ]
         }
@@ -12033,7 +12033,7 @@
               "name": "HV_CAPACITY_KWH",
               "expression": "[B4:B5]*50/1000",
               "unit": "kWh",
-              "class": "none"
+              "class": "energy"
             }
           ]
         },
@@ -12194,7 +12194,7 @@
               "name": "HV_C_V_001",
               "expression": "((B5*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12202,7 +12202,7 @@
               "name": "HV_C_V_002",
               "expression": "((B6*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12210,7 +12210,7 @@
               "name": "HV_C_V_003",
               "expression": "((B7*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12218,7 +12218,7 @@
               "name": "HV_C_V_004",
               "expression": "((B9*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12226,7 +12226,7 @@
               "name": "HV_C_V_005",
               "expression": "((B10*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12234,7 +12234,7 @@
               "name": "HV_C_V_006",
               "expression": "((B11*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12242,7 +12242,7 @@
               "name": "HV_C_V_007",
               "expression": "((B12*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12250,7 +12250,7 @@
               "name": "HV_C_V_008",
               "expression": "((B13*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12258,7 +12258,7 @@
               "name": "HV_C_V_009",
               "expression": "((B14*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12266,7 +12266,7 @@
               "name": "HV_C_V_010",
               "expression": "((B15*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12274,7 +12274,7 @@
               "name": "HV_C_V_011",
               "expression": "((B17*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12282,7 +12282,7 @@
               "name": "HV_C_V_012",
               "expression": "((B18*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12290,7 +12290,7 @@
               "name": "HV_C_V_013",
               "expression": "((B19*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12298,7 +12298,7 @@
               "name": "HV_C_V_014",
               "expression": "((B20*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12306,7 +12306,7 @@
               "name": "HV_C_V_015",
               "expression": "((B21*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12314,7 +12314,7 @@
               "name": "HV_C_V_016",
               "expression": "((B22*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12322,7 +12322,7 @@
               "name": "HV_C_V_017",
               "expression": "((B23*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12330,7 +12330,7 @@
               "name": "HV_C_V_018",
               "expression": "((B25*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12338,7 +12338,7 @@
               "name": "HV_C_V_019",
               "expression": "((B26*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12346,7 +12346,7 @@
               "name": "HV_C_V_020",
               "expression": "((B27*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12354,7 +12354,7 @@
               "name": "HV_C_V_021",
               "expression": "((B28*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12362,7 +12362,7 @@
               "name": "HV_C_V_022",
               "expression": "((B29*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12370,7 +12370,7 @@
               "name": "HV_C_V_023",
               "expression": "((B30*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12378,7 +12378,7 @@
               "name": "HV_C_V_024",
               "expression": "((B31*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12386,7 +12386,7 @@
               "name": "HV_C_V_025",
               "expression": "((B33*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12394,7 +12394,7 @@
               "name": "HV_C_V_026",
               "expression": "((B34*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12402,7 +12402,7 @@
               "name": "HV_C_V_027",
               "expression": "((B35*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12410,7 +12410,7 @@
               "name": "HV_C_V_028",
               "expression": "((B36*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12418,7 +12418,7 @@
               "name": "HV_C_V_029",
               "expression": "((B37*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12426,7 +12426,7 @@
               "name": "HV_C_V_030",
               "expression": "((B38*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12434,7 +12434,7 @@
               "name": "HV_C_V_031",
               "expression": "((B39*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12442,7 +12442,7 @@
               "name": "HV_C_V_032",
               "expression": "((B41*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12450,7 +12450,7 @@
               "name": "HV_C_V_033",
               "expression": "((B42*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12458,7 +12458,7 @@
               "name": "HV_C_V_034",
               "expression": "((B43*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12466,7 +12466,7 @@
               "name": "HV_C_V_035",
               "expression": "((B44*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12474,7 +12474,7 @@
               "name": "HV_C_V_036",
               "expression": "((B45*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12482,7 +12482,7 @@
               "name": "HV_C_V_037",
               "expression": "((B46*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12490,7 +12490,7 @@
               "name": "HV_C_V_038",
               "expression": "((B47*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12498,7 +12498,7 @@
               "name": "HV_C_V_039",
               "expression": "((B49*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12506,7 +12506,7 @@
               "name": "HV_C_V_040",
               "expression": "((B50*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12514,7 +12514,7 @@
               "name": "HV_C_V_041",
               "expression": "((B51*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12522,7 +12522,7 @@
               "name": "HV_C_V_042",
               "expression": "((B52*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12530,7 +12530,7 @@
               "name": "HV_C_V_043",
               "expression": "((B53*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12538,7 +12538,7 @@
               "name": "HV_C_V_044",
               "expression": "((B54*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12546,7 +12546,7 @@
               "name": "HV_C_V_045",
               "expression": "((B55*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12554,7 +12554,7 @@
               "name": "HV_C_V_046",
               "expression": "((B57*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12562,7 +12562,7 @@
               "name": "HV_C_V_047",
               "expression": "((B58*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12570,7 +12570,7 @@
               "name": "HV_C_V_048",
               "expression": "((B59*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12578,7 +12578,7 @@
               "name": "HV_C_V_049",
               "expression": "((B60*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12586,7 +12586,7 @@
               "name": "HV_C_V_050",
               "expression": "((B61*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12594,7 +12594,7 @@
               "name": "HV_C_V_051",
               "expression": "((B62*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12602,7 +12602,7 @@
               "name": "HV_C_V_052",
               "expression": "((B63*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12610,7 +12610,7 @@
               "name": "HV_C_V_053",
               "expression": "((B65*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12618,7 +12618,7 @@
               "name": "HV_C_V_054",
               "expression": "((B66*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12626,7 +12626,7 @@
               "name": "HV_C_V_055",
               "expression": "((B67*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12634,7 +12634,7 @@
               "name": "HV_C_V_056",
               "expression": "((B68*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12642,7 +12642,7 @@
               "name": "HV_C_V_057",
               "expression": "((B69*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12650,7 +12650,7 @@
               "name": "HV_C_V_058",
               "expression": "((B70*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12658,7 +12658,7 @@
               "name": "HV_C_V_059",
               "expression": "((B71*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12666,7 +12666,7 @@
               "name": "HV_C_V_060",
               "expression": "((B73*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12674,7 +12674,7 @@
               "name": "HV_C_V_061",
               "expression": "((B74*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12682,7 +12682,7 @@
               "name": "HV_C_V_062",
               "expression": "((B75*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12690,7 +12690,7 @@
               "name": "HV_C_V_063",
               "expression": "((B76*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12698,7 +12698,7 @@
               "name": "HV_C_V_064",
               "expression": "((B77*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12706,7 +12706,7 @@
               "name": "HV_C_V_065",
               "expression": "((B78*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12714,7 +12714,7 @@
               "name": "HV_C_V_066",
               "expression": "((B79*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12722,7 +12722,7 @@
               "name": "HV_C_V_067",
               "expression": "((B81*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12730,7 +12730,7 @@
               "name": "HV_C_V_068",
               "expression": "((B82*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12738,7 +12738,7 @@
               "name": "HV_C_V_069",
               "expression": "((B83*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12746,7 +12746,7 @@
               "name": "HV_C_V_070",
               "expression": "((B84*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12754,7 +12754,7 @@
               "name": "HV_C_V_071",
               "expression": "((B85*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12762,7 +12762,7 @@
               "name": "HV_C_V_072",
               "expression": "((B86*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12770,7 +12770,7 @@
               "name": "HV_C_V_073",
               "expression": "((B87*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12778,7 +12778,7 @@
               "name": "HV_C_V_074",
               "expression": "((B89*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12786,7 +12786,7 @@
               "name": "HV_C_V_075",
               "expression": "((B90*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12794,7 +12794,7 @@
               "name": "HV_C_V_076",
               "expression": "((B91*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12802,7 +12802,7 @@
               "name": "HV_C_V_077",
               "expression": "((B92*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12810,7 +12810,7 @@
               "name": "HV_C_V_078",
               "expression": "((B93*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12818,7 +12818,7 @@
               "name": "HV_C_V_079",
               "expression": "((B94*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12826,7 +12826,7 @@
               "name": "HV_C_V_080",
               "expression": "((B95*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12834,7 +12834,7 @@
               "name": "HV_C_V_081",
               "expression": "((B97*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12842,7 +12842,7 @@
               "name": "HV_C_V_082",
               "expression": "((B98*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12850,7 +12850,7 @@
               "name": "HV_C_V_083",
               "expression": "((B99*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12858,7 +12858,7 @@
               "name": "HV_C_V_084",
               "expression": "((B100*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12866,7 +12866,7 @@
               "name": "HV_C_V_085",
               "expression": "((B101*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12874,7 +12874,7 @@
               "name": "HV_C_V_086",
               "expression": "((B102*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12882,7 +12882,7 @@
               "name": "HV_C_V_087",
               "expression": "((B103*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12890,7 +12890,7 @@
               "name": "HV_C_V_088",
               "expression": "((B105*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12898,7 +12898,7 @@
               "name": "HV_C_V_089",
               "expression": "((B106*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12906,7 +12906,7 @@
               "name": "HV_C_V_090",
               "expression": "((B107*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12914,7 +12914,7 @@
               "name": "HV_C_V_091",
               "expression": "((B108*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12922,7 +12922,7 @@
               "name": "HV_C_V_092",
               "expression": "((B109*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12930,7 +12930,7 @@
               "name": "HV_C_V_093",
               "expression": "((B110*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12938,7 +12938,7 @@
               "name": "HV_C_V_094",
               "expression": "((B111*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12946,7 +12946,7 @@
               "name": "HV_C_V_095",
               "expression": "((B113*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12954,7 +12954,7 @@
               "name": "HV_C_V_096",
               "expression": "((B114*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12962,7 +12962,7 @@
               "name": "HV_C_V_097",
               "expression": "((B115*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12970,7 +12970,7 @@
               "name": "HV_C_V_098",
               "expression": "((B116*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12978,7 +12978,7 @@
               "name": "HV_C_V_099",
               "expression": "((B117*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12986,7 +12986,7 @@
               "name": "HV_C_V_100",
               "expression": "((B118*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -12994,7 +12994,7 @@
               "name": "HV_C_V_101",
               "expression": "((B119*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13002,7 +13002,7 @@
               "name": "HV_C_V_102",
               "expression": "((B121*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13010,7 +13010,7 @@
               "name": "HV_C_V_103",
               "expression": "((B122*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13018,7 +13018,7 @@
               "name": "HV_C_V_104",
               "expression": "((B123*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13026,7 +13026,7 @@
               "name": "HV_C_V_105",
               "expression": "((B124*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13034,7 +13034,7 @@
               "name": "HV_C_V_106",
               "expression": "((B125*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13042,7 +13042,7 @@
               "name": "HV_C_V_107",
               "expression": "((B126*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13050,7 +13050,7 @@
               "name": "HV_C_V_108",
               "expression": "((B127*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13058,7 +13058,7 @@
               "name": "HV_C_V_109",
               "expression": "((B129*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13066,7 +13066,7 @@
               "name": "HV_C_V_110",
               "expression": "((B130*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13074,7 +13074,7 @@
               "name": "HV_C_V_111",
               "expression": "((B131*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13082,7 +13082,7 @@
               "name": "HV_C_V_112",
               "expression": "((B132*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13090,7 +13090,7 @@
               "name": "HV_C_V_113",
               "expression": "((B133*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13098,7 +13098,7 @@
               "name": "HV_C_V_114",
               "expression": "((B134*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13106,7 +13106,7 @@
               "name": "HV_C_V_115",
               "expression": "((B135*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13114,7 +13114,7 @@
               "name": "HV_C_V_116",
               "expression": "((B137*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13122,7 +13122,7 @@
               "name": "HV_C_V_117",
               "expression": "((B138*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13130,7 +13130,7 @@
               "name": "HV_C_V_118",
               "expression": "((B139*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13138,7 +13138,7 @@
               "name": "HV_C_V_119",
               "expression": "((B140*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13146,7 +13146,7 @@
               "name": "HV_C_V_120",
               "expression": "((B141*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13154,7 +13154,7 @@
               "name": "HV_C_V_121",
               "expression": "((B142*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13162,7 +13162,7 @@
               "name": "HV_C_V_122",
               "expression": "((B143*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13170,7 +13170,7 @@
               "name": "HV_C_V_123",
               "expression": "((B145*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13178,7 +13178,7 @@
               "name": "HV_C_V_124",
               "expression": "((B146*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13186,7 +13186,7 @@
               "name": "HV_C_V_125",
               "expression": "((B147*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13194,7 +13194,7 @@
               "name": "HV_C_V_126",
               "expression": "((B148*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13202,7 +13202,7 @@
               "name": "HV_C_V_127",
               "expression": "((B149*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13210,7 +13210,7 @@
               "name": "HV_C_V_128",
               "expression": "((B150*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13218,7 +13218,7 @@
               "name": "HV_C_V_129",
               "expression": "((B151*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13226,7 +13226,7 @@
               "name": "HV_C_V_130",
               "expression": "((B153*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13234,7 +13234,7 @@
               "name": "HV_C_V_131",
               "expression": "((B154*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13242,7 +13242,7 @@
               "name": "HV_C_V_132",
               "expression": "((B155*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13250,7 +13250,7 @@
               "name": "HV_C_V_133",
               "expression": "((B156*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13258,7 +13258,7 @@
               "name": "HV_C_V_134",
               "expression": "((B157*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13266,7 +13266,7 @@
               "name": "HV_C_V_135",
               "expression": "((B158*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13274,7 +13274,7 @@
               "name": "HV_C_V_136",
               "expression": "((B159*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13282,7 +13282,7 @@
               "name": "HV_C_V_137",
               "expression": "((B161*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13290,7 +13290,7 @@
               "name": "HV_C_V_138",
               "expression": "((B162*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13298,7 +13298,7 @@
               "name": "HV_C_V_139",
               "expression": "((B163*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13306,7 +13306,7 @@
               "name": "HV_C_V_140",
               "expression": "((B164*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13314,7 +13314,7 @@
               "name": "HV_C_V_141",
               "expression": "((B165*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13322,7 +13322,7 @@
               "name": "HV_C_V_142",
               "expression": "((B166*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13330,7 +13330,7 @@
               "name": "HV_C_V_143",
               "expression": "((B167*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13338,7 +13338,7 @@
               "name": "HV_C_V_144",
               "expression": "((B169*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13346,7 +13346,7 @@
               "name": "HV_C_V_145",
               "expression": "((B170*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13354,7 +13354,7 @@
               "name": "HV_C_V_146",
               "expression": "((B171*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13362,7 +13362,7 @@
               "name": "HV_C_V_147",
               "expression": "((B172*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13370,7 +13370,7 @@
               "name": "HV_C_V_148",
               "expression": "((B173*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13378,7 +13378,7 @@
               "name": "HV_C_V_149",
               "expression": "((B174*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13386,7 +13386,7 @@
               "name": "HV_C_V_150",
               "expression": "((B175*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13394,7 +13394,7 @@
               "name": "HV_C_V_151",
               "expression": "((B177*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13402,7 +13402,7 @@
               "name": "HV_C_V_152",
               "expression": "((B178*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13410,7 +13410,7 @@
               "name": "HV_C_V_153",
               "expression": "((B179*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13418,7 +13418,7 @@
               "name": "HV_C_V_154",
               "expression": "((B180*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13426,7 +13426,7 @@
               "name": "HV_C_V_155",
               "expression": "((B181*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13434,7 +13434,7 @@
               "name": "HV_C_V_156",
               "expression": "((B182*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13442,7 +13442,7 @@
               "name": "HV_C_V_157",
               "expression": "((B183*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13450,7 +13450,7 @@
               "name": "HV_C_V_158",
               "expression": "((B185*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13458,7 +13458,7 @@
               "name": "HV_C_V_159",
               "expression": "((B186*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13466,7 +13466,7 @@
               "name": "HV_C_V_160",
               "expression": "((B187*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13474,7 +13474,7 @@
               "name": "HV_C_V_161",
               "expression": "((B188*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13482,7 +13482,7 @@
               "name": "HV_C_V_162",
               "expression": "((B189*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13490,7 +13490,7 @@
               "name": "HV_C_V_163",
               "expression": "((B190*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13498,7 +13498,7 @@
               "name": "HV_C_V_164",
               "expression": "((B191*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13506,7 +13506,7 @@
               "name": "HV_C_V_165",
               "expression": "((B193*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13514,7 +13514,7 @@
               "name": "HV_C_V_166",
               "expression": "((B194*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13522,7 +13522,7 @@
               "name": "HV_C_V_167",
               "expression": "((B195*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13530,7 +13530,7 @@
               "name": "HV_C_V_168",
               "expression": "((B196*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13538,7 +13538,7 @@
               "name": "HV_C_V_169",
               "expression": "((B197*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13546,7 +13546,7 @@
               "name": "HV_C_V_170",
               "expression": "((B198*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13554,7 +13554,7 @@
               "name": "HV_C_V_171",
               "expression": "((B199*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13562,7 +13562,7 @@
               "name": "HV_C_V_172",
               "expression": "((B201*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13570,7 +13570,7 @@
               "name": "HV_C_V_173",
               "expression": "((B202*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13578,7 +13578,7 @@
               "name": "HV_C_V_174",
               "expression": "((B203*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13586,7 +13586,7 @@
               "name": "HV_C_V_175",
               "expression": "((B204*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13594,7 +13594,7 @@
               "name": "HV_C_V_176",
               "expression": "((B205*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13602,7 +13602,7 @@
               "name": "HV_C_V_177",
               "expression": "((B206*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13610,7 +13610,7 @@
               "name": "HV_C_V_178",
               "expression": "((B207*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13618,7 +13618,7 @@
               "name": "HV_C_V_179",
               "expression": "((B209*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13626,7 +13626,7 @@
               "name": "HV_C_V_180",
               "expression": "((B210*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13634,7 +13634,7 @@
               "name": "HV_C_V_181",
               "expression": "((B211*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13642,7 +13642,7 @@
               "name": "HV_C_V_182",
               "expression": "((B212*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13650,7 +13650,7 @@
               "name": "HV_C_V_183",
               "expression": "((B213*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13658,7 +13658,7 @@
               "name": "HV_C_V_184",
               "expression": "((B214*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13666,7 +13666,7 @@
               "name": "HV_C_V_185",
               "expression": "((B215*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13674,7 +13674,7 @@
               "name": "HV_C_V_186",
               "expression": "((B217*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13682,7 +13682,7 @@
               "name": "HV_C_V_187",
               "expression": "((B218*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13690,7 +13690,7 @@
               "name": "HV_C_V_188",
               "expression": "((B219*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13698,7 +13698,7 @@
               "name": "HV_C_V_189",
               "expression": "((B220*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13706,7 +13706,7 @@
               "name": "HV_C_V_190",
               "expression": "((B221*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13714,7 +13714,7 @@
               "name": "HV_C_V_191",
               "expression": "((B222*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             },
@@ -13722,7 +13722,7 @@
               "name": "HV_C_V_192",
               "expression": "((B223*2)/100)",
               "unit": "V",
-              "class": "battery",
+              "class": "voltage",
               "min": "0",
               "max": "10"
             }


### PR DESCRIPTION
Updated inconsistently used unit and class definitions.
* kwh -> kWh
* for Amps battery -> current
* for Volts battery -> voltage
* for kWh battery -> energy