### PR TITLE
Add more fields for Chevy Bolt

### DIFF
--- a/vehicle_profiles/chevrolet/bolt.json
+++ b/vehicle_profiles/chevrolet/bolt.json
@@ -6,7 +6,14 @@
       "pid": "2283341",
       "pid_init": "ATSH7E4",
       "parameters": {
-        "SOC": "(B4*100)/255"
+        "SOC_D": "(B4*100)/255"
+      }
+    },
+    {
+      "pid": "2243AF1",
+      "pid_init": "ATSH7E4",
+      "parameters": {
+        "SOC": "([B4:B5]*100)/65535"
       }
     },
     {
@@ -15,6 +22,62 @@
       "parameters": {
         "BATT_CAPACITY": "[B4:B5]/10"
       }
-    }
+    },
+    {
+      "pid": "2243681",
+      "pid_init": "ATSH7E4",
+      "parameters": {
+        "AC_C_V": "B4*2"
+      }
+    },
+    {
+      "pid": "2243691",
+      "pid_init": "ATSH7E4",
+      "parameters": {
+        "AC_C_C": "B4*0.2"
+      }
+    },
+    {
+      "pid": "2243561",
+      "pid_init": "ATSH7E4",
+      "parameters": {
+        "HV_A": "(0-[S4:S5])/6.675"
+      }
+    },
+    {
+      "pid": "2241C41",
+      "pid_init": "ATSH7E4",
+      "parameters": {
+        "HV_V": "[B4:B5]/40"
+      }
+    },
+    {
+      "pid": "2243891",
+      "pid_init": "ATSH7E4",
+      "parameters": {
+        "KWH_CHARGED": "[B5:B7]/100"
+      }
+    },
+    {
+      "pid": "22437D1",
+      "pid_init": "ATSH7E4",
+      "parameters": {
+        "KWH_DISCHARGED": "[B4:B5]/100"
+      }
+    },
+    {
+      "pid": "2241AB1",
+      "pid_init": "ATSH7E4",
+      "parameters": {
+        "DIST_SINCE_FULL_CHARGE": "[B4:B7]/64"
+      }
+    },
+    {
+      "pid": "2234B21",
+      "pid_init": "ATSH7E0",
+      "parameters": {
+        "ODOMETER_MI": "[B4:B7]/103"
+      }
+    }    
   ]
 }


### PR DESCRIPTION
Added new fields for Chevy Bolt:

- SOC/SOC_D  - %battery - internal battery vs display
- BATT_CAPACITY - capacity in kwh
- AC_C_V - AC voltage (when charging)
- AC_C_C - AC current (when charging)
- HV_A - DC current
- HV_V - DC voltage
- KWH_CHARGED - Lifetime charge in kwh
- KWH_DISCHARGED - last session charge
- DIST_SINCE_FULL_CHARGE - distance since last full charge
- ODOMETER_MI - odometer