### PR TITLE
Publish last-known AutoPID values on MQTT (re)connect, periodically, and before sleep

### DIFF
--- a/docs/content/0.Config/6.Automate/1.Usage.md
+++ b/docs/content/0.Config/6.Automate/1.Usage.md
@@ -39,6 +39,20 @@ Responses can be monitored:
 
 - **Cycle Time(ms)**: The interval in milliseconds at which the system will request the configured PIDs. In the example, it's set to 5000ms (5 seconds).
 
+## Cached Republish (last-known values)
+
+By default a parameter is only published to MQTT when the ECU is successfully read. When the vehicle powers down (for example when it is parked at home) the ECU stops responding, so Home Assistant keeps showing stale data from the previous drive and never receives the value the car had on arrival.
+
+These options republish the **last-known value** of every parameter (the value from the last successful read is kept in memory) so consumers stay in sync even when the ECU is unreachable. They are all opt-in; leaving them at their defaults keeps the previous behaviour.
+
+- **Publish cached on MQTT connect**: When enabled, the last-known values are published immediately after the device (re)connects to the MQTT broker. This is the key setting for the "car arrives home, connects to WiFi, then sleeps" scenario — Home Assistant receives the arrival values right away.
+
+- **Republish period (s)**: When set to a non-zero value, the last-known values are republished every N seconds while online, even if no fresh reading was obtained. Set to `0` to disable. (With **Grouping** enabled the group snapshot is already republished every *Cycle Time*, so this is mainly useful for per-parameter destinations.)
+
+- **Publish before sleep**: When enabled, a final snapshot of the last-known values is published just before the device goes to sleep, while WiFi/MQTT are still up.
+
+- **Add age/stale metadata**: When enabled, republished (cached) messages carry an extra `"_meta": { "age": <seconds since last read>, "stale": <true|false> }` object so consumers can distinguish cached data from a fresh reading. Fresh (live) publishes are never modified. A value is considered `stale` when it is older than its polling period.
+
 ## Standard PIDs
 
 - **Standard PIDs**: Enable this option to use the standardized OBD-II PIDs defined in the SAE J1979 standard. A list of standard PIDs is available on https://en.wikipedia.org/wiki/OBD-II_PIDs#Standard_PIDs. Most vehicles support a number of these standard PIDs; however, not all car manufacturers expose all of these PIDs. For example, some vehicles might not support Odometer reading or Fuel level through standard PIDs, instead making them available through vehicle-specific PIDs.

--- a/main/autopid.c
+++ b/main/autopid.c
@@ -1014,6 +1014,204 @@ void autopid_data_publish(void) {
     }
 }
 
+// Append "_meta":{"age":<seconds>,"stale":<bool>} to a cached snapshot so consumers
+// (e.g. Home Assistant) can tell a republished cached value from a fresh reading.
+// age is the age of the oldest value in the message (-1 if never read this boot).
+static void cached_add_meta(cJSON *root, int64_t now_us, int64_t oldest_update_us, bool any_stale)
+{
+    if (!root)
+    {
+        return;
+    }
+    cJSON *meta = cJSON_CreateObject();
+    if (!meta)
+    {
+        return;
+    }
+    int64_t age_s = (oldest_update_us > 0) ? (now_us - oldest_update_us) / 1000000 : -1;
+    cJSON_AddNumberToObject(meta, "age", (double)age_s);
+    cJSON_AddBoolToObject(meta, "stale", any_stale);
+    cJSON_AddItemToObject(root, "_meta", meta);
+}
+
+/*
+ * Republish the last-known ("cached") value of every parameter, even when the ECU is
+ * currently unreachable (e.g. the car is parked at home and no longer answering, but
+ * WiFi/MQTT are up). This keeps Home Assistant in sync with the value from the last
+ * successful read instead of showing nothing / a value from the previous drive.
+ *
+ * Routing mirrors the normal publish path so consumers see the same topics/format:
+ *   - grouping enabled + MQTT topic -> one JSON snapshot to the group destination
+ *   - otherwise                     -> one message per parameter that has an MQTT destination
+ * When include_meta is set, a "_meta" object with age/stale info is appended. See issue #825.
+ */
+void autopid_publish_cached(bool include_meta)
+{
+    if (!all_pids || !all_pids->mutex)
+    {
+        return;
+    }
+
+    // Nothing to do if MQTT isn't usable; mqtt_publish() would drop the message anyway.
+    if (config_server_mqtt_en_config() != 1 || !mqtt_connected())
+    {
+        return;
+    }
+
+    int64_t now = esp_timer_get_time();
+
+    if (xSemaphoreTake(all_pids->mutex, portMAX_DELAY) != pdTRUE)
+    {
+        return;
+    }
+
+    bool group_mode = (all_pids->grouping &&
+                       strcmp("enable", all_pids->grouping) == 0 &&
+                       all_pids->group_destination_type == DEST_MQTT_TOPIC);
+
+    if (group_mode)
+    {
+        cJSON *root = cJSON_CreateObject();
+        if (root)
+        {
+            bool any = false;
+            bool any_stale = false;
+            int64_t oldest_update = 0;
+
+            for (uint32_t i = 0; i < all_pids->pid_count; i++)
+            {
+                pid_data2_t *curr_pid = &all_pids->pids[i];
+                for (uint32_t j = 0; j < curr_pid->parameters_count; j++)
+                {
+                    parameter_t *param = &curr_pid->parameters[j];
+                    if (param->name && param->value != FLT_MAX)
+                    {
+                        if (param->sensor_type == BINARY_SENSOR)
+                        {
+                            cJSON_AddStringToObject(root, param->name, param->value > 0 ? "on" : "off");
+                        }
+                        else
+                        {
+                            cJSON_AddNumberToObject(root, param->name, param->value);
+                        }
+                        any = true;
+
+                        if (param->last_update > 0 &&
+                            (oldest_update == 0 || param->last_update < oldest_update))
+                        {
+                            oldest_update = param->last_update;
+                        }
+                        if (param->last_update == 0 ||
+                            (now - param->last_update) > ((int64_t)param->period * 1000))
+                        {
+                            any_stale = true;
+                        }
+                    }
+                }
+            }
+
+            if (any)
+            {
+                limitJsonDecimalPrecision(root);
+                if (include_meta)
+                {
+                    cached_add_meta(root, now, oldest_update, any_stale);
+                }
+                char *json_str = cJSON_PrintUnformatted(root);
+                if (json_str)
+                {
+                    if (all_pids->group_destination && strlen(all_pids->group_destination) > 0)
+                    {
+                        mqtt_publish(all_pids->group_destination, json_str, 0, 0, 1);
+                    }
+                    else
+                    {
+                        mqtt_publish(config_server_get_mqtt_rx_topic(), json_str, 0, 0, 1);
+                    }
+                    free(json_str);
+                    ESP_LOGI(TAG, "Published cached snapshot (group)");
+                    DEBUG_LOGI(TAG, "Published cached snapshot (group)");
+                }
+            }
+            cJSON_Delete(root);
+        }
+    }
+    else
+    {
+        // Per-parameter routing: mirror publish_parameter_mqtt() but from cached values.
+        for (uint32_t i = 0; i < all_pids->pid_count; i++)
+        {
+            pid_data2_t *curr_pid = &all_pids->pids[i];
+            for (uint32_t j = 0; j < curr_pid->parameters_count; j++)
+            {
+                parameter_t *param = &curr_pid->parameters[j];
+                if (!param->name || param->value == FLT_MAX)
+                {
+                    continue;
+                }
+
+                char *payload = NULL;
+
+                if (param->destination_type == DEST_MQTT_TOPIC)
+                {
+                    cJSON *param_json = cJSON_CreateObject();
+                    if (param_json)
+                    {
+                        if (param->sensor_type == BINARY_SENSOR)
+                        {
+                            cJSON_AddStringToObject(param_json, param->name, param->value > 0 ? "on" : "off");
+                        }
+                        else
+                        {
+                            cJSON_AddNumberToObject(param_json, param->name, param->value);
+                        }
+                        limitJsonDecimalPrecision(param_json);
+                        if (include_meta)
+                        {
+                            bool stale = (param->last_update == 0 ||
+                                          (now - param->last_update) > ((int64_t)param->period * 1000));
+                            cached_add_meta(param_json, now, param->last_update, stale);
+                        }
+                        payload = cJSON_PrintUnformatted(param_json);
+                        cJSON_Delete(param_json);
+                    }
+                }
+                else if (param->destination_type == DEST_MQTT_WALLBOX)
+                {
+                    asprintf(&payload, "%.2f", param->value);
+                }
+
+                if (payload)
+                {
+                    if (param->destination && strlen(param->destination) > 0)
+                    {
+                        mqtt_publish(param->destination, payload, 0, 0, 1);
+                    }
+                    else
+                    {
+                        mqtt_publish(config_server_get_mqtt_rx_topic(), payload, 0, 0, 1);
+                    }
+                    free(payload);
+                }
+            }
+        }
+        ESP_LOGI(TAG, "Published cached snapshot (per-parameter)");
+        DEBUG_LOGI(TAG, "Published cached snapshot (per-parameter)");
+    }
+
+    xSemaphoreGive(all_pids->mutex);
+}
+
+// Called from the sleep path just before WiFi/MQTT are torn down.
+void autopid_publish_before_sleep(void)
+{
+    if (!all_pids || !all_pids->pub_before_sleep)
+    {
+        return;
+    }
+    autopid_publish_cached(all_pids->cached_meta);
+}
+
 bool autopid_get_ecu_status(void)
 {
 	EventBits_t uxBits;
@@ -1518,6 +1716,8 @@ static void autopid_task(void *pvParameters)
     static char default_init[] = "ati\rate0\rath1\ratl0\rats1\ratsp6\ratst96\r";
     wc_timer_t ecu_check_timer;
     wc_timer_t group_cycle_timer;
+    wc_timer_t republish_timer = 0;
+    bool prev_mqtt_connected = false;
 
     ESP_LOGI(TAG, "Autopid Task Started");
     DEBUG_LOGI(TAG, "Autopid Task Started");
@@ -1575,7 +1775,26 @@ static void autopid_task(void *pvParameters)
 
         dev_status_wait_for_bits(DEV_AWAKE_BIT, portMAX_DELAY);
 
-        if (xEventGroupGetBits(xautopid_event_group) & AUTOPID_POLLING_DISABLED_BIT) 
+        // --- Cached-value republishing triggers (issue #825) ---
+        // Keep Home Assistant in sync with the last-known reading even when the ECU has
+        // stopped answering (car parked) but WiFi/MQTT are up.
+        bool mqtt_now = mqtt_connected();
+        if (all_pids->pub_cached_on_connect && mqtt_now && !prev_mqtt_connected)
+        {
+            ESP_LOGI(TAG, "MQTT (re)connected - publishing cached snapshot");
+            DEBUG_LOGI(TAG, "MQTT (re)connected - publishing cached snapshot");
+            autopid_publish_cached(all_pids->cached_meta);
+            wc_timer_set(&republish_timer, (uint64_t)all_pids->republish_period * 1000);
+        }
+        prev_mqtt_connected = mqtt_now;
+
+        if (all_pids->republish_period > 0 && mqtt_now && wc_timer_is_expired(&republish_timer))
+        {
+            wc_timer_set(&republish_timer, (uint64_t)all_pids->republish_period * 1000);
+            autopid_publish_cached(all_pids->cached_meta);
+        }
+
+        if (xEventGroupGetBits(xautopid_event_group) & AUTOPID_POLLING_DISABLED_BIT)
         {
             xEventGroupWaitBits(xautopid_event_group, AUTOPID_REQUEST_BIT, pdFALSE, pdTRUE, portMAX_DELAY);
         }
@@ -1700,9 +1919,10 @@ static void autopid_task(void *pvParameters)
                                                         param->name, result, param->max);
                                             } else {
                                                 result = round(result * 100.0) / 100.0;
-                                                ESP_LOGI(TAG, "Parameter %s result: %.2f", 
+                                                ESP_LOGI(TAG, "Parameter %s result: %.2f",
                                                         param->name, result);
                                                 param->value = result;
+                                                param->last_update = esp_timer_get_time();
                                                 publish_parameter_mqtt(param);
                                             }
                                         }
@@ -1755,6 +1975,7 @@ static void autopid_task(void *pvParameters)
                                                                         param->value, 
                                                                         pid_info->params[p].unit);
                                                         param->value = roundf(param->value * 100.0) / 100.0;
+                                                        param->last_update = esp_timer_get_time();
                                                         publish_parameter_mqtt(param);
                                                         break;
                                                     }
@@ -1898,6 +2119,10 @@ all_pids_t* load_all_pids(void){
             cJSON* specific_pids_item = cJSON_GetObjectItem(root, "car_specific");
             cJSON* group_destination_item = cJSON_GetObjectItem(root, "destination");
             cJSON* group_dest_type_item = cJSON_GetObjectItem(root, "group_dest_type");
+            cJSON* pub_on_connect_item = cJSON_GetObjectItem(root, "pub_cached_on_connect");
+            cJSON* republish_period_item = cJSON_GetObjectItem(root, "republish_period");
+            cJSON* pub_before_sleep_item = cJSON_GetObjectItem(root, "pub_before_sleep");
+            cJSON* cached_meta_item = cJSON_GetObjectItem(root, "cached_meta");
 
             if (init_item && init_item->valuestring) {
                 all_pids->custom_init = strdup(init_item->valuestring);
@@ -1926,7 +2151,29 @@ all_pids_t* load_all_pids(void){
             all_pids->group_destination_type = group_dest_type_item && group_dest_type_item->valuestring ?
                             (strcmp(group_dest_type_item->valuestring, "MQTT_Topic") == 0 ? DEST_MQTT_TOPIC :
                             DEST_DEFAULT) : DEST_DEFAULT;
-            
+
+            // Cached-value republishing (issue #825). All opt-in; defaults keep legacy behaviour.
+            all_pids->pub_cached_on_connect = (pub_on_connect_item && pub_on_connect_item->valuestring) ?
+                            (strcmp(pub_on_connect_item->valuestring, "enable") == 0) : false;
+            all_pids->pub_before_sleep = (pub_before_sleep_item && pub_before_sleep_item->valuestring) ?
+                            (strcmp(pub_before_sleep_item->valuestring, "enable") == 0) : false;
+            all_pids->cached_meta = (cached_meta_item && cached_meta_item->valuestring) ?
+                            (strcmp(cached_meta_item->valuestring, "enable") == 0) : false;
+            if (republish_period_item)
+            {
+                if (cJSON_IsNumber(republish_period_item))
+                {
+                    all_pids->republish_period = (uint32_t)republish_period_item->valueint;
+                }
+                else if (republish_period_item->valuestring)
+                {
+                    all_pids->republish_period = (uint32_t)atoi(republish_period_item->valuestring);
+                }
+            }
+            ESP_LOGI(TAG, "Cached republish: on_connect=%d, period=%lus, before_sleep=%d, meta=%d",
+                    all_pids->pub_cached_on_connect, all_pids->republish_period,
+                    all_pids->pub_before_sleep, all_pids->cached_meta);
+
             // Load custom pids
             cJSON* pids = cJSON_GetObjectItem(root, "pids");
             if (pids) {

--- a/main/autopid.h
+++ b/main/autopid.h
@@ -71,6 +71,7 @@ typedef struct
     int64_t timer;
     float value;
     bool failed;
+    int64_t last_update;    // esp_timer_get_time() (us) of last successful read, 0 = never
 }parameter_t;
 
 typedef struct 
@@ -104,6 +105,12 @@ typedef struct
     char* vehicle_model;
     bool ha_discovery_en;
     uint32_t cycle;     //To be removed when std pid gets its own period
+    // Cached-value republishing (issue #825): keep Home Assistant in sync with the
+    // last-known reading even when the ECU stops responding (e.g. car parked at home).
+    bool pub_cached_on_connect;     // republish last-known snapshot right after MQTT (re)connects
+    uint32_t republish_period;      // republish last-known snapshot every N seconds while online (0 = off)
+    bool pub_before_sleep;          // republish last-known snapshot once, just before going to sleep
+    bool cached_meta;               // add "_meta":{"age","stale"} to republished (cached) messages
     SemaphoreHandle_t mutex;
 }all_pids_t;
 
@@ -129,4 +136,6 @@ bool autopid_get_ecu_status(void);
 char* autopid_get_config(void);
 esp_err_t autopid_find_standard_pid(uint8_t protocol, char *available_pids, uint32_t available_pids_size) ;
 void autopid_request_data(void);
+void autopid_publish_cached(bool include_meta);
+void autopid_publish_before_sleep(void);
 #endif

--- a/main/homepage_full.html
+++ b/main/homepage_full.html
@@ -942,6 +942,42 @@
                     </td>
                 </tr>
             </table>
+            <div class="section-title" style="margin-top:1rem;">Cached Republish (last-known values)</div>
+            <table class="form-table">
+                <tr>
+                    <td>Publish cached on MQTT connect:</td>
+                    <td>
+                        <select id="pub_cached_on_connect" name="pub_cached_on_connect" onchange="enableAutoStoreButton();submit_enable();">
+                            <option value="disable">Disable</option>
+                            <option value="enable">Enable</option>
+                        </select>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Republish period (s, 0 = off):</td>
+                    <td>
+                        <input type="number" id="republish_period" name="republish_period" min="0" max="86400" value="0" oninput="enableAutoStoreButton();submit_enable();">
+                    </td>
+                </tr>
+                <tr>
+                    <td>Publish before sleep:</td>
+                    <td>
+                        <select id="pub_before_sleep" name="pub_before_sleep" onchange="enableAutoStoreButton();submit_enable();">
+                            <option value="disable">Disable</option>
+                            <option value="enable">Enable</option>
+                        </select>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Add age/stale metadata:</td>
+                    <td>
+                        <select id="cached_meta" name="cached_meta" onchange="enableAutoStoreButton();submit_enable();">
+                            <option value="disable">Disable</option>
+                            <option value="enable">Enable</option>
+                        </select>
+                    </td>
+                </tr>
+            </table>
             <div class="section-title">Standard PIDs</div>
             <table class="form-table">
                 <tr>
@@ -1927,7 +1963,11 @@ function loadAutoTable(jsonData) {
             setElementValue("standard_pids", data.standard_pids, 'disable');
             setElementValue("ecu_protocol", data.ecu_protocol, '6');
             setElementValue("group_dest_type", data.group_dest_type, 'Default');
-            
+            setElementValue("pub_cached_on_connect", data.pub_cached_on_connect, 'disable');
+            setElementValue("republish_period", data.republish_period, '0');
+            setElementValue("pub_before_sleep", data.pub_before_sleep, 'disable');
+            setElementValue("cached_meta", data.cached_meta, 'disable');
+
             if (data.pids && Array.isArray(data.pids)) {
                 data.pids.forEach((pidData, index) => {
                     console.log(`Loading PID ${index}:`, pidData);
@@ -2035,6 +2075,11 @@ function loadAutoTable(jsonData) {
             const carModelField = document.getElementById("car_model");
             const standard_pidsValue = document.getElementById("standard_pids")?.value || 'disable';
             const ecu_protocolValue = document.getElementById("ecu_protocol")?.value || '6';
+            const pubCachedOnConnectValue = document.getElementById("pub_cached_on_connect")?.value || 'disable';
+            const pubBeforeSleepValue = document.getElementById("pub_before_sleep")?.value || 'disable';
+            const cachedMetaValue = document.getElementById("cached_meta")?.value || 'disable';
+            let republishPeriodValue = document.getElementById("republish_period")?.value || '0';
+            if (!/^\d+$/.test(republishPeriodValue)) { republishPeriodValue = '0'; }
             const carModelValue = carModelField?.value || '';
             if (carSpecificValue== "enable" && (!carModelValue || carModelValue.length === 0 || carModelValue === "Not Selected")) {
                 throw new Error("Car model must be selected");
@@ -2156,7 +2201,11 @@ function loadAutoTable(jsonData) {
                 pids: custom_pid_data,
                 std_pids: std_pid_data,
                 standard_pids: standard_pidsValue,
-                ecu_protocol: ecu_protocolValue
+                ecu_protocol: ecu_protocolValue,
+                pub_cached_on_connect: pubCachedOnConnectValue,
+                republish_period: republishPeriodValue,
+                pub_before_sleep: pubBeforeSleepValue,
+                cached_meta: cachedMetaValue
             };
 
             // Send to server

--- a/main/sleep_mode.c
+++ b/main/sleep_mode.c
@@ -58,6 +58,7 @@
 #include "ver.h"
 #include "math.h"
 #include "dev_status.h"
+#include "autopid.h"
 
 #define TAG 			  __func__
 
@@ -399,6 +400,10 @@ static void adc_task(void *pvParameters)
 
 					if((esp_timer_get_time() - sleep_detect_time) > sleep_time)
 					{
+						// Flush the last-known AutoPID values while WiFi/MQTT are still up,
+						// so Home Assistant gets a final snapshot before sleep (issue #825).
+						autopid_publish_before_sleep();
+						vTaskDelay(pdMS_TO_TICKS(100));
 						sleep_state = SLEEP_STATE;
 	//    	    		wifi_network_deinit();
 	//    	    		ble_disable();


### PR DESCRIPTION
Closes #825

> ℹ️ **Disclosure:** This change was written by **Claude Opus** (Anthropic's AI coding assistant) together with the reporter of #825, who reviewed it. It has **not** been compiled with ESP-IDF in that environment — please build before merging. Feedback very welcome.

### Problem
Today an AutoPID parameter is only published to MQTT when the ECU is read **successfully**. When the vehicle powers down — the classic *"car arrives home, WiCAN connects to home WiFi/MQTT, then the ECU stops answering and the device sleeps"* case — no message is ever sent, so Home Assistant keeps showing stale data from the previous drive and never receives the value the car had on arrival (e.g. the arrival state-of-charge).

The last good reading is already kept in memory (`param->value` survives failed reads); it just isn't republished.

### Solution
Three **opt-in** triggers that republish the last-known ("cached") snapshot, plus optional staleness metadata. Everything is **off by default**, so existing behaviour is unchanged.

| Setting (Automate UI / `auto_pid.json`) | Effect |
| --- | --- |
| **Publish cached on MQTT connect** — `pub_cached_on_connect` | Publishes the last-known values immediately after MQTT (re)connects. Headline fix for the arrival scenario. |
| **Republish period (s)** — `republish_period` | Republishes the snapshot every N seconds while online, even without a fresh read. `0` = off. (With Grouping enabled the group snapshot is already resent every *Cycle Time*, so this mainly helps per-parameter destinations.) |
| **Publish before sleep** — `pub_before_sleep` | Publishes one final snapshot just before the device sleeps, while WiFi/MQTT are still up. |
| **Add age/stale metadata** — `cached_meta` | Adds `"_meta":{"age":<s>,"stale":<bool>}` to **republished** messages only. |

Routing mirrors the normal publish path, so consumers see the same topics/format:
- **Grouping + MQTT topic** → one JSON snapshot to the group destination.
- **Otherwise** → one message per parameter that has an MQTT destination.

Fresh (live) publishes are **never** modified. Only the cached republish carries `_meta` (when enabled):

```json
{ "SoC": 63, "_meta": { "age": 154, "stale": true } }
```

`age` is the age (seconds) of the oldest value in the message; `stale` is true when a value is older than its polling period.

### Implementation
- `parameter_t` gains `int64_t last_update` (µs of last successful read) so `age`/`stale` can be computed.
- `all_pids_t` gains the four config fields; parsed from `auto_pid.json` in `load_all_pids()` (defaults preserve legacy behaviour).
- New `autopid_publish_cached(bool include_meta)` builds and sends the snapshot; it takes `all_pids->mutex` and no-ops when MQTT is unusable or when there are no cached values yet.
- The connect edge + periodic timer live at the top of `autopid_task()`; `autopid_publish_before_sleep()` is called from `sleep_mode.c` right before WiFi/MQTT teardown.
- Web UI: a new **"Cached Republish"** section in the Automate settings (`homepage_full.html`), wired into load + save. Docs updated in `docs/content/0.Config/6.Automate/1.Usage.md`.

### Recommended settings for the "car comes home" use case
Enable **Publish cached on MQTT connect** (and optionally **Publish before sleep**). Home Assistant then receives the arrival values the moment WiCAN connects, before the device sleeps.

### Notes / limitations
- The connect/periodic triggers run from the AutoPID task loop, which iterates continuously when **Polling** is *enabled* (the default). With Polling *disabled* the task only runs on demand, so the connect publish fires on the next data request rather than instantly.
- The before-sleep publish is best-effort (QoS 0, small flush delay before WiFi is torn down).
- Not built with ESP-IDF in my environment; the change is self-contained and hand-reviewed, but please compile before merging.
