### PR TITLE
Add Honda WN7 vehicle profile

### DIFF
--- a/vehicle_profiles/honda/wn7.json
+++ b/vehicle_profiles/honda/wn7.json
@@ -34,7 +34,8 @@
             "pid": "22DB009",
             "pid_init": "ATSHDACBF1;",
             "parameters": {
-                "CHARGER_CONNECTED": "(B15-1)/2"
+                "CHARGER_CONNECTED": "(B15-1)/2",
+                "CHARGING": "B14-1"
             }
         }
     ]

--- a/vehicle_profiles/honda/wn7.json
+++ b/vehicle_profiles/honda/wn7.json
@@ -1,0 +1,20 @@
+{
+    "car_model": "Honda: WN7",
+    "init": "ATSP7;ATST96;",
+    "pids": [
+        {
+            "pid": "22A8709",
+            "pid_init": "ATSHDAD4F1;",
+            "parameters": {
+                "SOC": "[B59:B60]*0.11266+2.457"
+            }
+        },
+        {
+            "pid": "22F0122",
+            "pid_init": "ATSHDADEF1;",
+            "parameters": {
+                "ODOMETER": "[B6:B7]*6553.6+[B9:B10]*0.1"
+            }
+        }
+    ]
+}

--- a/vehicle_profiles/honda/wn7.json
+++ b/vehicle_profiles/honda/wn7.json
@@ -6,7 +6,11 @@
             "pid": "22A8709",
             "pid_init": "ATSHDAD4F1;",
             "parameters": {
-                "SOC": "[B59:B60]*0.11266+2.457"
+                "SOC": "[B52:B53]*0.01",
+                "HV_V": "[B19:B20]*0.1",
+                "HV_A": "((S21*256)+B22)*0.1",
+                "BATT_TEMP": "B47-40",
+                "SOH": "B61"
             }
         },
         {
@@ -14,6 +18,23 @@
             "pid_init": "ATSHDADEF1;",
             "parameters": {
                 "ODOMETER": "[B6:B7]*6553.6+[B9:B10]*0.1"
+            }
+        },
+        {
+            "pid": "22CFA29",
+            "pid_init": "ATSHDADEF1;",
+            "parameters": {
+                "SOC_D": "B39",
+                "OUTSIDE_TEMPERATURE": "B26",
+                "HV_C_V_MAX": "[B41:B42]/5000",
+                "HV_C_V_MIN": "[B43:B44]/5000"
+            }
+        },
+        {
+            "pid": "22DB009",
+            "pid_init": "ATSHDACBF1;",
+            "parameters": {
+                "CHARGER_CONNECTED": "(B15-1)/2"
             }
         }
     ]


### PR DESCRIPTION
Adds a vehicle profile for the **Honda WN7** (2026 electric motorcycle, EU market), tested on real hardware with firmware v4.21.

**Update 2026-08-11:** extended from the initial SOC+odometer pair to the full parameter set below. All byte positions were since **cross-verified against a passive CAN capture of Honda's official MCS diagnostic tool** and its all-systems report (values matched report entries 1:1).

**Update 2026-08-30:** added `CHARGING`, the charge-active flag, verified during a real AC charging session.

**Parameters** (all short names already exist in `params.json`, no additions needed):

| Param | ECU | DID | Notes |
|---|---|---|---|
| `SOC` | `0xD4` (BMU), `ATSHDAD4F1;` | `22 A870` (9 frames) | BMS "In-Fact SOC" ×0.01 — the BMS's own SOC field (replaces the earlier calibrated remaining-energy formula, which drifts midrange) |
| `HV_V` | `0xD4` | `22 A870` | pack voltage ×0.1 (~392 V nominal) |
| `HV_A` | `0xD4` | `22 A870` | pack current, signed 16-bit ×0.1 (negative = charging) |
| `BATT_TEMP` | `0xD4` | `22 A870` | max cell temperature, −40 offset |
| `SOH` | `0xD4` | `22 A870` | battery state of health, % |
| `ODOMETER` | `0xDE` (cluster), `ATSHDADEF1;` | `22 F012` (2 frames) | 32-bit, 0.1 km resolution; split expression because the value crosses the FF/CF boundary (PCI bytes included in indexing); matches display exactly |
| `SOC_D` | `0xDE` | `22 CFA2` (9 frames) | SOC exactly as the TFT displays it (integer) |
| `OUTSIDE_TEMPERATURE` | `0xDE` | `22 CFA2` | ambient °C, no offset |
| `HV_C_V_MAX` / `HV_C_V_MIN` | `0xDE` | `22 CFA2` | highest/lowest cell voltage, V |
| `CHARGER_CONNECTED` | `0xCB` (PCU), `ATSHDACBF1;` | `22 DB00` (9 frames) | byte 9: raw 1 = no cable, 3 = plugged → mapped to 0/1 |
| `CHARGING` | `0xCB` | `22 DB00` | byte 8: raw 1 = not charging, 2 = charging → mapped to 0/1. Needed because the plug byte stays at 3 for the whole session and cannot distinguish plugged-and-idle from actively charging |

Bus is 29-bit / 500k (`ATSP7`), default headers/flow control work — no `ATCRA`/`ATFCSH` needed.

Full derivation, verification data and protocol notes are documented here: https://github.com/cnc-lasercraft/honda-wn7-wican

🤖 Generated with [Claude Code](https://claude.com/claude-code)