### PR TITLE
Vehicle Workflow ❌Error❌ Fix & pwn Requests Prevention

### DIFF
--- a/.github/workflows/vehicle_profiles_pr.yml
+++ b/.github/workflows/vehicle_profiles_pr.yml
@@ -2,17 +2,17 @@ name: PR Workflow for Vehicle Profiles
 
 permissions:
   contents: read
-  pull-requests: write
-  issues: write
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - 'vehicle_profiles/**'
       - '.vehicle_profiles/**'
 
 jobs:
   vehicle-profiles-check:
+    outputs:
+      artifact-url: ${{ steps.upload.outputs.artifact-url }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -57,11 +57,18 @@ jobs:
           name: vehicle_profiles.json
           path: ${{ github.workspace }}/vehicle_profiles.json # Relative to the working-directory
 
+  comment-on-pr:
+    needs: vehicle-profiles-check
+    if: needs.vehicle-profiles-check.result == 'success' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
       - name: Comment on PR with testing instructions
-        if: success()
         uses: actions/github-script@v7
         env:
-          link: '${{steps.upload.outputs.artifact-url}}'
+          link: '${{ needs.vehicle-profiles-check.outputs.artifact-url }}'
         with:
           script: |
             const prNumber = context.payload.pull_request.number;


### PR DESCRIPTION
This PR fixes _**Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow**_ for the **PR Workflow for Vehicle Profiles** workflow by no longer executing the "Comment on PR with testing instructions" step when a forked branch is targeting the base repository.

This allowed the workflow to run in the forked repository's security context (i.e. ```pull_request_target``` changed to ```pull_request```) rather than the (less secure) base repository’s security context (see https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/).

This does mean that there would be no comment in PRs from forks of non-vetted contributors but this seems better than using the ```allow-unsafe-pr-checkout``` option. I should note that non-vetted contributors always have the option of creating temporary pull requests targeting their own fork if they want this convenient link to the ```vehicle_profiles.json``` build artifact.