### PR TITLE
comm_server: disable Nagle on the OBD socket

### DIFF
--- a/main/comm_server.c
+++ b/main/comm_server.c
@@ -320,6 +320,10 @@ accept_socket:
 			setsockopt(sock, IPPROTO_TCP, TCP_KEEPIDLE, &keepIdle, sizeof(int));
 			setsockopt(sock, IPPROTO_TCP, TCP_KEEPINTVL, &keepInterval, sizeof(int));
 			setsockopt(sock, IPPROTO_TCP, TCP_KEEPCNT, &keepCount, sizeof(int));
+			// OBD traffic is small request/response exchanges where latency
+			// matters and there is nothing to coalesce across.
+			int nodelay = 1;
+			setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
 			// Convert ip address to string
 			if (source_addr.ss_family == PF_INET)
 			{


### PR DESCRIPTION
The accepted socket was left with Nagle enabled. OBD traffic is a series of small request/response exchanges, so there is nothing useful to coalesce across, and every response after the first segment waits on the client's delayed ACK - 40-200 ms of added latency per exchange.

Set TCP_NODELAY after accept(), alongside the keepalive options.