### PR TITLE
elm327: drain the stale RX queue with a zero timeout

### DIFF
--- a/main/elm327.c
+++ b/main/elm327.c
@@ -834,7 +834,10 @@ static int8_t elm327_request(char *cmd, char *rsp, QueueHandle_t *queue)
 	{
 		elm327_can_log(&txframe, ELM327_CAN_TX);
 	}
-	while( xQueueReceive(*can_rx_queue, ( void * ) &rx_frame, pdMS_TO_TICKS(1)) == pdPASS );
+	// Drain with a zero timeout: the final iteration otherwise always
+	// blocks a full tick (CONFIG_FREERTOS_HZ=1000), adding >= 1 ms of dead
+	// time to every OBD command.
+	while( xQueueReceive(*can_rx_queue, ( void * ) &rx_frame, 0) == pdPASS );
 	can_flush_rx();
 	can_send(&txframe, 1);
 	xEventGroupSetBits(elm327_event_group, ELM327_READY_TO_RECEIVE_CAN);


### PR DESCRIPTION
The pre-request drain used pdMS_TO_TICKS(1). The loop exits when the queue is empty, so its final iteration always blocked for a full tick - and with CONFIG_FREERTOS_HZ at 1000 that is 1 ms added to every OBD command.

Discarding stale frames does not require waiting for new ones.