### PR TITLE
autopid: drain send_commands responses with a zero timeout

### DIFF
--- a/main/autopid.c
+++ b/main/autopid.c
@@ -1438,7 +1438,12 @@ static void send_commands(char *commands, uint32_t delay_ms)
             (strstr(str_send, "ate1") == NULL && strstr(str_send, "ATE1") == NULL && strstr(str_send, "at e1") == NULL && strstr(str_send, "AT E1") == NULL))
         {
             elm327_process_cmd((uint8_t *)str_send, cmd_len, &tx_msg, &autopidQueue);
-            while ((xQueueReceive(autopidQueue, &elm327_response, pdMS_TO_TICKS(10)) == pdPASS));
+            // elm327_process_cmd queues every response synchronously before
+            // returning, so the drain never needs to wait; a per-item
+            // timeout only added 10 ms of dead time to its final (empty)
+            // iteration. With the e-Golf profile's 3-6-command pid_init on
+            // every PID that was ~70 ms of pure overhead per PID.
+            while ((xQueueReceive(autopidQueue, &elm327_response, 0) == pdPASS));
         }
         
         cmd_start = cmd_end + 1; // Move to the start of the next command


### PR DESCRIPTION
send_commands() drained the response queue with a 10 ms per-item timeout, so the final empty iteration always blocked the full 10 ms.

elm327_process_cmd() queues every response synchronously before it returns, so there is nothing to wait for. With a profile that sets a 3-6 command pid_init on each PID this was around 70 ms of dead time per PID.