### PR TITLE
main: clamp send_to_host payload to the buffer size

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -155,6 +155,12 @@ void send_to_host(char* str, uint32_t len, QueueHandle_t *q)
 	{
 		xsend_buffer.usLen = len;
 	}
+	if(xsend_buffer.usLen > DEV_BUFFER_LENGTH)
+	{
+		ESP_LOGW(TAG, "send_to_host: truncating %lu-byte payload to %d bytes",
+			 (unsigned long)xsend_buffer.usLen, DEV_BUFFER_LENGTH);
+		xsend_buffer.usLen = DEV_BUFFER_LENGTH;
+	}
 	memcpy(xsend_buffer.ucElement, str, xsend_buffer.usLen);
 	xQueueSend( *q, ( void * ) &xsend_buffer, portMAX_DELAY );
 


### PR DESCRIPTION
send_to_host() memcpy'd len bytes into a shared static xdev_buffer whose ucElement is DEV_BUFFER_LENGTH (65) bytes, with no bound check. elm327.c passes a 128-byte cmd_response, so a long enough response would smash whatever follows the buffer - and because the buffer is static and shared by every protocol handler wired to send_to_host, the damage would not be confined to one path.

Clamp to DEV_BUFFER_LENGTH and warn when truncating.