### PR TITLE
vehicle_profiles: sort params.json and Supported_Parameters.md in one build

### DIFF
--- a/.vehicle_profiles/src/params.js
+++ b/.vehicle_profiles/src/params.js
@@ -11,7 +11,7 @@ const PARAM_PATH_IN_SCHEMA =
 let params = null;
 
 export async function process_params() {
-  let params = await get_params();
+  params = await get_params();
   params = sortPackageJson(params);
   await writeFile(PARAMS_PATH, JSON.stringify(params, null, 2));
 


### PR DESCRIPTION
process_params() shadowed the module-level params cache with a local, so the sorted object was written to params.json but never stored back. save_params_md() runs later in the same build, reads the cache, and got the pre-sort order - leaving Supported_Parameters.md ordered differently from params.json unless the build was run twice.

Assign to the module-level binding instead. get_params() is also imported by cars.js, which saw the same stale cache.