### PR TITLE
elm327: take the mutex with portMAX_DELAY

### DIFF
--- a/main/elm327.c
+++ b/main/elm327.c
@@ -1042,7 +1042,10 @@ const xelm327_cmd_t elm327_commands[] = {
 
 void elm327_lock(void)
 {
-	xSemaphoreTake(elm327_mutex, pdMS_TO_TICKS(portMAX_DELAY));
+	// Take forever: pdMS_TO_TICKS(portMAX_DELAY) overflows in 32-bit to a
+	// finite ~71-minute timeout, and the discarded return value meant a
+	// timed-out caller proceeded without the lock.
+	xSemaphoreTake(elm327_mutex, portMAX_DELAY);
 }
 void elm327_unlock(void)
 {


### PR DESCRIPTION
elm327_lock() called xSemaphoreTake(mutex, pdMS_TO_TICKS(portMAX_DELAY)). pdMS_TO_TICKS multiplies by the tick rate before dividing by 1000, so 0xFFFFFFFF overflows 32-bit arithmetic and yields a finite timeout of about 71 minutes rather than an infinite wait. The return value was discarded, so on expiry the caller would proceed without holding the lock and race the autopid task through the ELM327 state.

Pass portMAX_DELAY directly.