### PR TITLE
autopid: terminate pid_init with a carriage return

### DIFF
--- a/main/autopid.c
+++ b/main/autopid.c
@@ -1433,7 +1433,11 @@ static void send_commands(char *commands, uint32_t delay_ms)
         char str_send[cmd_len + 1]; // +1 for null terminator
         strncpy(str_send, cmd_start, cmd_len);
         str_send[cmd_len] = '\0'; // Null-terminate the command string
-        if ((strstr(str_send, "ath0") == NULL && strstr(str_send, "ATH0") == NULL && strstr(str_send, "at h0") == NULL && strstr(str_send, "AT H0") == NULL) &&
+        // Skip empty commands: a pid_init that already ends in ';' becomes
+        // "...\r\r" once the trailing '\r' is appended, and the empty
+        // command between the two '\r' must not be sent to the ELM327.
+        if (cmd_len > 1 &&
+            (strstr(str_send, "ath0") == NULL && strstr(str_send, "ATH0") == NULL && strstr(str_send, "at h0") == NULL && strstr(str_send, "AT H0") == NULL) &&
             (strstr(str_send, "ats0") == NULL && strstr(str_send, "ATS0") == NULL && strstr(str_send, "at s0") == NULL && strstr(str_send, "AT s0") == NULL) &&
             (strstr(str_send, "ate1") == NULL && strstr(str_send, "ATE1") == NULL && strstr(str_send, "at e1") == NULL && strstr(str_send, "AT E1") == NULL))
         {
@@ -1968,7 +1972,8 @@ all_pids_t* load_all_pids(void){
                             curr_pid->init = (char*)malloc(init_len + 2);
                             if (curr_pid->init) {
                                 strncpy(curr_pid->init, init_item->valuestring, init_len);
-                                curr_pid->init[init_len] = '\0';
+                                curr_pid->init[init_len]     = '\r';
+                                curr_pid->init[init_len + 1] = '\0';
                                 
                                 // Replace semicolons with carriage returns
                                 for (size_t j = 0; j < init_len; j++) {
@@ -2168,7 +2173,8 @@ all_pids_t* load_all_pids(void){
                                     curr_pid->init = (char*)malloc(init_len + 2);
                                     if (curr_pid->init) {
                                         strncpy(curr_pid->init, init_item->valuestring, init_len);
-                                        curr_pid->init[init_len] = '\0';
+                                        curr_pid->init[init_len]     = '\r';
+                                        curr_pid->init[init_len + 1] = '\0';
                                         
                                         // Replace semicolons with carriage returns
                                         for (size_t j = 0; j < init_len; j++) {


### PR DESCRIPTION
load_all_pids() allocates init_len + 2 bytes for a PID's init string, copies the JSON value in and NUL-terminates it at init_len - never writing the trailing '\r' the extra byte was allocated for. send_commands() splits on '\r', so the final command of every pid_init was silently dropped unless the profile author happened to end the string with ';'.

The cmd field twenty lines below already does this correctly.

Write '\r' then '\0', and skip zero-length commands in send_commands() so a pid_init that already ends in ';' produces '...\r\r' harmlessly.

This is the root cause behind
https://github.com/meatpiHQ/wican-fw/pull/879, which added the missing semicolons to ten profiles. With this fix those workarounds are unnecessary and any profile still missing one works.