### PR TITLE
autopid: drop negative-response frames before evaluating expressions

### DIFF
--- a/main/autopid.c
+++ b/main/autopid.c
@@ -1212,6 +1212,7 @@ void parse_elm327_response(char *buffer, response_t *response) {
     
     int k = 0;
     int frame_count = 0;
+    int response_failed = 0;
     char *frame;
     char *data_start;
     uint32_t lowest_header = UINT32_MAX;  // Initialize to maximum value
@@ -1274,6 +1275,41 @@ void parse_elm327_response(char *buffer, response_t *response) {
                     ESP_LOGW(TAG, "Unexpected header length: %d, skipping frame", header_length);
                     frame = strtok(NULL, "\r\n");
                     continue;
+            }
+
+            // Skip negative responses (service byte 0x7F, e.g. 7F 22 78
+            // response-pending) that can precede the real response.
+            // Concatenating them into the response buffer shifts the byte
+            // indices and makes expressions evaluate garbage. NRC 0x78 means
+            // the request is still being processed and the real response will
+            // follow; any other NRC means the request was rejected.
+            {
+                char *nrc_data = data_start;
+                int nrc_bytes[4] = {0, 0, 0, 0};
+                int nrc_count = 0;
+                while (*nrc_data != '\0' && nrc_count < 4)
+                {
+                    if (*nrc_data == ' ')
+                    {
+                        nrc_data++;
+                        continue;
+                    }
+                    if (strlen(nrc_data) < 2) break;
+                    char byte_str[3] = {nrc_data[0], nrc_data[1], 0};
+                    nrc_bytes[nrc_count++] = (int)strtol(byte_str, NULL, 16);
+                    nrc_data += 2;
+                }
+                if (nrc_count >= 2 && nrc_bytes[0] >= 1 && nrc_bytes[0] <= 7 &&
+                    nrc_bytes[1] == 0x7F)
+                {
+                    if (nrc_count < 4 || nrc_bytes[3] != 0x78)
+                    {
+                        // Terminal negative response: the request was rejected.
+                        response_failed = 1;
+                    }
+                    frame = strtok(NULL, "\r\n");
+                    continue;
+                }
             }
 
             // Store start position for copying data
@@ -1345,7 +1381,31 @@ void parse_elm327_response(char *buffer, response_t *response) {
         frame = strtok(NULL, "\r\n");
     }
 
-    response->length = k;
+    if (response_failed || k == 0)
+    {
+        // No usable data: the request was rejected with a terminal negative
+        // response or only response-pending frames were received. Report an
+        // error so the parameter is marked as failed instead of evaluating
+        // garbage.
+        sprintf((char*)response->data, "error");
+        response->length = strlen((char*)response->data);
+        // The caller short-circuits on the "error" string and never frees
+        // priority_data, so any per-frame buffer collected so far would
+        // leak. Drop it and force the priority_data assignment below to
+        // produce NULL.
+        if (lowest_header_data != NULL)
+        {
+            free(lowest_header_data);
+            lowest_header_data = NULL;
+            lowest_header_length = 0;
+        }
+        frame_count = 0;
+        all_headers_same = true;
+    }
+    else
+    {
+        response->length = k;
+    }
     
     // Set priority data based on frame count and header comparison
     if (frame_count <= 2 || all_headers_same) {


### PR DESCRIPTION
parse_elm327_response() copied every frame into response->data without looking at it, so a negative response ended up prepended to the payload and the parameter expression was evaluated against the wrong bytes.

Two cases, both seen on a VW e-Golf:

  - 7F xx 78 (responsePending). The ECU answers 'wait', then sends the real reply. 22149A returned '03 7F 22 78' followed by '05 62 14 9A 00 02' on roughly one poll in six; concatenated, [S4:S5] read 0x0562 = 689 rpm instead of 1 rpm, and 689 sits inside the parameter's valid range so it was published rather than rejected.

  - Any other NRC (7F xx 31 requestOutOfRange and friends). The request was refused, so there is no data at all - the response is now marked failed instead of evaluating whatever bytes happen to follow.

Detect a negative response by its shape (single-frame PCI 1..7, service byte 0x7F) and skip the frame before the byte copy. Pending frames are dropped silently; terminal ones fail the response. On the failure path the per-frame heap buffer is released and the priority-data bookkeeping reset, so the error return cannot leak or hand out a stale pointer.

Supersedes https://github.com/meatpiHQ/wican-fw/pull/783, which fixes the same responsePending bug on the Ioniq 5. That patch compares the assembled buffer against the literal 03 7F 22 78, which is narrower in three ways: it only matches service 0x22 and PCI 0x03, it only works when the pending frame is the first one in the buffer (the length counter it tests is cumulative), and it leaves terminal NRCs to be evaluated as data. Handling it per frame by shape covers every service, any position, and both NRC classes.