### PR TITLE
WiCAN Pro: Fix SLCAN TX TCP drain stall and post-open enable-bit race

### DIFF
--- a/main/can.c
+++ b/main/can.c
@@ -168,8 +168,12 @@ void can_enable(void)
 		return;
 	}
 	twai_clear_receive_queue();
-	can_unblock();
 	can_cfg.bus_state = ON_BUS;
+	/*
+	 * Enable TX/RX immediately. Delayed can_unblock() left CAN_ENABLE_BIT clear for
+	 * ~10ms after SLCAN 'O', so early can_send() failed (host TX never reached the bus).
+	 */
+	xEventGroupSetBits(s_can_event_group, CAN_ENABLE_BIT);
 	vTaskDelay(pdMS_TO_TICKS(2));
 	gpio_set_level(CAN_STDBY_GPIO_NUM, 0);
 }
@@ -376,12 +380,12 @@ esp_err_t can_receive(twai_message_t *message, TickType_t ticks_to_wait)
 
 esp_err_t can_send(twai_message_t *message, TickType_t ticks_to_wait)
 {
-//	xEventGroupWaitBits(s_can_event_group,
-//							CAN_ENABLE_BIT,
-//							pdFALSE,
-//							pdFALSE,
-//							portMAX_DELAY);
-	EventBits_t uxBits = xEventGroupGetBits(s_can_event_group);
+	EventBits_t uxBits = xEventGroupWaitBits(
+		s_can_event_group,
+		CAN_ENABLE_BIT,
+		pdFALSE,
+		pdFALSE,
+		pdMS_TO_TICKS(50));
 	esp_err_t ret;
 	twai_status_info_t status_info;
 

--- a/main/can.c
+++ b/main/can.c
@@ -382,12 +382,58 @@ esp_err_t can_send(twai_message_t *message, TickType_t ticks_to_wait)
 //							pdFALSE,
 //							portMAX_DELAY);
 	EventBits_t uxBits = xEventGroupGetBits(s_can_event_group);
+	esp_err_t ret;
+	twai_status_info_t status_info;
 
-	if(uxBits & CAN_ENABLE_BIT)
+	if(!(uxBits & CAN_ENABLE_BIT))
 	{
-		return twai_transmit(message, ticks_to_wait);
+		return ESP_ERR_INVALID_STATE;
 	}
-	else return ESP_ERR_INVALID_STATE;
+
+	ret = twai_transmit(message, ticks_to_wait);
+	if(ret == ESP_OK)
+	{
+		return ret;
+	}
+
+	if(twai_get_status_info(&status_info) == ESP_OK)
+	{
+		ESP_LOGW(TAG, "twai_transmit %s state=%d tec=%lu rec=%lu tx_q=%lu",
+				 esp_err_to_name(ret),
+				 (int)status_info.state,
+				 (unsigned long)status_info.tx_error_counter,
+				 (unsigned long)status_info.rx_error_counter,
+				 (unsigned long)status_info.msgs_to_tx);
+
+		if(status_info.state == TWAI_STATE_BUS_OFF)
+		{
+			ESP_LOGW(TAG, "CAN bus-off — initiating recovery");
+			if(twai_initiate_recovery() == ESP_OK)
+			{
+				/* Recovery finishes in TWAI_STATE_STOPPED; restart to go running again. */
+				for(int i = 0; i < 50; i++)
+				{
+					vTaskDelay(pdMS_TO_TICKS(10));
+					if(twai_get_status_info(&status_info) != ESP_OK)
+					{
+						break;
+					}
+					if(status_info.state == TWAI_STATE_STOPPED)
+					{
+						twai_start();
+						ESP_LOGW(TAG, "CAN recovered from bus-off");
+						break;
+					}
+					if(status_info.state == TWAI_STATE_RUNNING)
+					{
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	return ret;
 }
 
 bool can_is_enabled(void)

--- a/main/comm_server.c
+++ b/main/comm_server.c
@@ -20,6 +20,7 @@
 
 #include <string.h>
 #include <sys/param.h>
+#include <errno.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/event_groups.h"
@@ -207,31 +208,47 @@ wait_skt_tx:
 	ESP_LOGI(TAG, "Socket connected...");
 	while(1)
 	{
-		xQueuePeek(*xTX_Queue, ( void * ) &tx_buffer, portMAX_DELAY);
+		xQueueReceive(*xTX_Queue, ( void * ) &tx_buffer, portMAX_DELAY);
 
-		while(xQueuePeek(*xTX_Queue, ( void * ) &tx_buffer, 0) == pdTRUE)
+		int to_write = tx_buffer.usLen;
+		int stall_loops = 0;
+		while (to_write > 0)
 		{
-			if( xSemaphoreTake( xTCP_Socket_Semaphore, portMAX_DELAY ) == pdTRUE )
+			if( !(xEventGroupGetBits(xSocketEventGroup) & PORT_OPEN_BIT) )
 			{
-				int to_write = tx_buffer.usLen;
-				xQueueReceive(*xTX_Queue, ( void * ) &tx_buffer, 0);
-				while (to_write > 0)
+				goto wait_skt_tx;
+			}
+
+			if( xSemaphoreTake( xTCP_Socket_Semaphore, portMAX_DELAY ) != pdTRUE )
+			{
+				goto wait_skt_tx;
+			}
+
+			int written = send(sock, tx_buffer.ucElement + (tx_buffer.usLen - to_write), to_write, MSG_DONTWAIT);
+			if (written <= 0)
+			{
+				if (written < 0 && errno != EAGAIN && errno != EWOULDBLOCK)
 				{
-					int written = send(sock, tx_buffer.ucElement + (tx_buffer.usLen - to_write), to_write, 0);
-					if (written < 0)
-					{
-						ESP_LOGE(TAG, "Error occurred during sending: errno %d", errno);
-						xEventGroupSetBits( xSocketEventGroup, PORT_CLOSED_BIT );
-						xEventGroupClearBits( xSocketEventGroup, PORT_OPEN_BIT );
-						xSemaphoreGive( xTCP_Socket_Semaphore );
-						goto wait_skt_tx;
-					}
-					to_write -= written;
+					ESP_LOGE(TAG, "Error occurred during sending: errno %d", errno);
+					xEventGroupSetBits( xSocketEventGroup, PORT_CLOSED_BIT );
+					xEventGroupClearBits( xSocketEventGroup, PORT_OPEN_BIT );
+					xSemaphoreGive( xTCP_Socket_Semaphore );
+					goto wait_skt_tx;
 				}
+				/* Peer isn't reading — release sock lock so RX can still accept host commands. */
+				xSemaphoreGive( xTCP_Socket_Semaphore );
+				if (++stall_loops > 400) /* ~2s at 5ms */
+				{
+					ESP_LOGW(TAG, "TCP TX stalled, dropping %d bytes", tx_buffer.usLen);
+					break;
+				}
+				vTaskDelay(pdMS_TO_TICKS(5));
+				continue;
 			}
 			xSemaphoreGive( xTCP_Socket_Semaphore );
+			to_write -= written;
+			stall_loops = 0;
 		}
-		vTaskDelay(pdMS_TO_TICKS(1));
 	}
 }
 

--- a/main/main.c
+++ b/main/main.c
@@ -247,10 +247,15 @@ void send_to_host(char* str, uint32_t len, QueueHandle_t *q)
         memcpy(xsend_buffer.ucElement, str + bytes_sent, bytes_to_send);
         xsend_buffer.usLen = bytes_to_send;
 		ESP_LOG_BUFFER_HEXDUMP(TAG, xsend_buffer.ucElement, bytes_to_send, ESP_LOG_INFO);
-        // Send the buffer to the queue with a timeout
-        if (xQueueSend(*q, (void*)&xsend_buffer, pdMS_TO_TICKS(100)) != pdPASS)
+        /*
+         * Never block forever here. Host TX (SLCAN ACKs + CAN RX ASCII) shares this queue
+         * with tcp/ble/uart drain tasks. python-can's send() does not read the socket, so
+         * on a busy CAN bus a blocking xQueueSend would freeze can_tx_task.
+         */
+        if (xQueueSend(*q, (void*)&xsend_buffer, pdMS_TO_TICKS(20)) != pdPASS)
         {
-            ESP_LOGE(TAG, "Failed to send data to queue");
+            ESP_LOGW(TAG, "host TX queue full, dropping %d bytes (waiting=%u)",
+                     xsend_buffer.usLen, (unsigned)uxQueueMessagesWaiting(*q));
             return;
         }
 
@@ -269,6 +274,10 @@ static void can_tx_task(void *pvParameters)
 
 		memset(ucTCP_RX_Buffer.ucElement,0, DEV_BUFFER_LENGTH);
 		xQueueReceive(xMsg_Rx_Queue, &ucTCP_RX_Buffer, portMAX_DELAY);
+
+		dev_status_wait_for_bits(DEV_AWAKE_BIT, portMAX_DELAY);
+
+		memset(&tx_msg, 0, sizeof(tx_msg));
 		ESP_LOGI(TAG, "----------");
 		ESP_LOG_BUFFER_HEXDUMP(TAG, ucTCP_RX_Buffer.ucElement, ucTCP_RX_Buffer.usLen, ESP_LOG_INFO);
 		ESP_LOGI(TAG, "----------");
@@ -734,7 +743,7 @@ void app_main(void)
 	#endif
 	#if HARDWARE_VER == WICAN_V300 || HARDWARE_VER == WICAN_USB_V100
 	xMsg_Rx_Queue = xQueueCreate(32, sizeof( xdev_buffer) );
-    xMsg_Tx_Queue = xQueueCreate(32, sizeof( xdev_buffer) );
+    xMsg_Tx_Queue = xQueueCreate(64, sizeof( xdev_buffer) );
     xmsg_ws_tx_queue = xQueueCreate(32, sizeof( xdev_buffer) );
 	#elif HARDWARE_VER == WICAN_PRO
 	static xdev_buffer* xMsg_Rx_Queue_Storage;
@@ -747,7 +756,7 @@ void app_main(void)
 	size_t xdev_buffer_size = sizeof( xdev_buffer);
 	
     xMsg_Rx_Queue_Storage = (xdev_buffer *)heap_caps_malloc(32 * xdev_buffer_size, MALLOC_CAP_SPIRAM);
-    xMsg_Tx_Queue_Storage = (xdev_buffer *)heap_caps_malloc(32 * xdev_buffer_size, MALLOC_CAP_SPIRAM);
+    xMsg_Tx_Queue_Storage = (xdev_buffer *)heap_caps_malloc(64 * xdev_buffer_size, MALLOC_CAP_SPIRAM);
     xmsg_ws_tx_queue_Storage = (xdev_buffer *)heap_caps_malloc(32 * xdev_buffer_size, MALLOC_CAP_SPIRAM);
 
     // Check if memory allocation was successful
@@ -759,7 +768,7 @@ void app_main(void)
 
     // Create the static queues
     xMsg_Rx_Queue = xQueueCreateStatic(32, xdev_buffer_size, (uint8_t *)xMsg_Rx_Queue_Storage, &xMsg_Rx_Queue_Buffer);
-    xMsg_Tx_Queue = xQueueCreateStatic(32, xdev_buffer_size, (uint8_t *)xMsg_Tx_Queue_Storage, &xMsg_Tx_Queue_Buffer);
+    xMsg_Tx_Queue = xQueueCreateStatic(64, xdev_buffer_size, (uint8_t *)xMsg_Tx_Queue_Storage, &xMsg_Tx_Queue_Buffer);
     xmsg_ws_tx_queue = xQueueCreateStatic(32, xdev_buffer_size, (uint8_t *)xmsg_ws_tx_queue_Storage, &xmsg_ws_tx_queue_Buffer);
 
     // Check if queues were created successfully
@@ -769,7 +778,6 @@ void app_main(void)
         return;
     }
 	#endif
-
 
 	esp_ota_mark_app_valid_cancel_rollback();
 //    xmsg_obd_rx_queue = xQueueCreate(100, sizeof( twai_message_t) );

--- a/main/slcan.c
+++ b/main/slcan.c
@@ -149,43 +149,51 @@ static uint8_t ascii_to_num(uint8_t a)
 	return x;
 }
 
+static uint8_t slcan_frame_index = 0;
+static uint8_t slcan_frame_id[8] = {0};
+static uint8_t slcan_frame_data_nibble = 0;
+static uint8_t slcan_frame_state = SL_FRAME_ID;
+
+static void slcan_frame_parser_reset(void)
+{
+	slcan_frame_index = 0;
+	slcan_frame_data_nibble = 0;
+	slcan_frame_state = SL_FRAME_ID;
+	memset(slcan_frame_id, 0, sizeof(slcan_frame_id));
+}
+
 static uint8_t slcan_set_frame(uint8_t byte, twai_message_t *frame, uint8_t msg_type)
 {
-	static uint8_t index = 0;
-	static uint8_t id[8] = {0,0,0,0,0,0,0,0};
-	static uint8_t data = 0;
-	static uint8_t frame_state = SL_FRAME_ID;
-
-	switch(frame_state)
+	switch(slcan_frame_state)
 	{
 		case SL_FRAME_ID:
 		{
 			if(msg_type == SL_DATA_EXT || msg_type == SL_REMOTE_EXT)
 			{
-				id[index++] = ascii_to_num(byte);
+				slcan_frame_id[slcan_frame_index++] = ascii_to_num(byte);
 
-				if(index == 8)
+				if(slcan_frame_index == 8)
 				{
 					frame->extd = 1;
-					frame->identifier = (((id[6]<<4)+id[7]) & 0xFF) |
-							((((id[4]<<4)+id[5]) << 8) & 0x0000FF00) |
-							((((id[2]<<4)+id[3]) << 16) & 0x00FF0000) |
-							((((id[0]<<4)+id[1]) << 24) & 0xFF000000);
-					frame_state = SL_FRAME_DLC;
-					index = 0;
+					frame->identifier = (((slcan_frame_id[6]<<4)+slcan_frame_id[7]) & 0xFF) |
+							((((slcan_frame_id[4]<<4)+slcan_frame_id[5]) << 8) & 0x0000FF00) |
+							((((slcan_frame_id[2]<<4)+slcan_frame_id[3]) << 16) & 0x00FF0000) |
+							((((slcan_frame_id[0]<<4)+slcan_frame_id[1]) << 24) & 0xFF000000);
+					slcan_frame_state = SL_FRAME_DLC;
+					slcan_frame_index = 0;
 				}
 			}
 			else
 			{
-				id[index++] = ascii_to_num(byte);
+				slcan_frame_id[slcan_frame_index++] = ascii_to_num(byte);
 
-				if(index == 3)
+				if(slcan_frame_index == 3)
 				{
 					frame->extd = 0;
-					frame->identifier = (((id[1]<<4)+id[2]) & 0xFF) |
-							((id[0]<<8) & 0x00000F00) ;
-					frame_state = SL_FRAME_DLC;
-					index = 0;
+					frame->identifier = (((slcan_frame_id[1]<<4)+slcan_frame_id[2]) & 0xFF) |
+							((slcan_frame_id[0]<<8) & 0x00000F00) ;
+					slcan_frame_state = SL_FRAME_DLC;
+					slcan_frame_index = 0;
 				}
 			}
 			return 0;
@@ -196,36 +204,30 @@ static uint8_t slcan_set_frame(uint8_t byte, twai_message_t *frame, uint8_t msg_
 
 			if(msg_type == SL_REMOTE_STD || msg_type == SL_REMOTE_EXT)
 			{
-				frame_state = SL_FRAME_ID;
-				index = 0;
-				data = 0;
-				memset(id, 0,sizeof(id));
+				slcan_frame_parser_reset();
 				return 1;
 			}
 
-			frame_state = SL_FRAME_DATA;
+			slcan_frame_state = SL_FRAME_DATA;
 			return 0;
 		}
 		case SL_FRAME_DATA:
 		{
 
-			if((index+1)%2)
+			if((slcan_frame_index+1)%2)
 			{
-				data = ascii_to_num(byte);
+				slcan_frame_data_nibble = ascii_to_num(byte);
 			}
 			else
 			{
-				frame->data[index/2] = (data<<4)+ascii_to_num(byte);
+				frame->data[slcan_frame_index/2] = (slcan_frame_data_nibble<<4)+ascii_to_num(byte);
 			}
 
-			index++;
+			slcan_frame_index++;
 
-			if(index == frame->data_length_code*2)
+			if(slcan_frame_index == frame->data_length_code*2)
 			{
-				frame_state = SL_FRAME_ID;
-				index = 0;
-				data = 0;
-				memset(id, 0,sizeof(id));
+				slcan_frame_parser_reset();
 				return 1;
 			}
 
@@ -238,7 +240,7 @@ static uint8_t slcan_set_frame(uint8_t byte, twai_message_t *frame, uint8_t msg_
 char* slcan_parse_str(uint8_t *buf, uint8_t len, twai_message_t *frame, QueueHandle_t *q)
 {
 //	twai_message_t frame;
-	uint8_t i;
+	uint32_t i;
 	static uint8_t state = SL_HEADER;
 	static uint8_t cmd = SL_NONE;
 //	static uint8_t ext_flag = 0;
@@ -252,19 +254,34 @@ char* slcan_parse_str(uint8_t *buf, uint8_t len, twai_message_t *frame, QueueHan
 	static uint32_t buffer_index = 0;
 
 	time_now = esp_timer_get_time();
-    memcpy(&slcan_buffer[buffer_index], buf, len);
-    buffer_index += len;
-	
-	if(time_now - time_old > 100*1000)
+
+	/* Idle gap: drop incomplete prior command before appending the new chunk. */
+	if(time_old != 0 && (time_now - time_old > 100*1000))
 	{
 		state = SL_HEADER;
 		cmd = SL_NONE;
-//		ext_flag = 0;
 		cmd_ret = SL_NONE;
 		msg_index = 0;
 		buffer_index = 0;
+		slcan_frame_parser_reset();
 	}
-	for(i = 0; i < len; i++)
+
+	if(buffer_index + len > SLCAN_BUFFER_SIZE)
+	{
+		ESP_LOGW(TAG, "SLCAN buffer overflow, resetting parser");
+		state = SL_HEADER;
+		cmd = SL_NONE;
+		cmd_ret = SL_NONE;
+		msg_index = 0;
+		buffer_index = 0;
+		slcan_frame_parser_reset();
+	}
+
+	memcpy(&slcan_buffer[buffer_index], buf, len);
+	buffer_index += len;
+	time_old = time_now;
+
+	for(i = 0; i < buffer_index; i++)
 	{
 		switch(state)
 		{
@@ -423,7 +440,6 @@ char* slcan_parse_str(uint8_t *buf, uint8_t len, twai_message_t *frame, QueueHan
 			}
 			case SL_BODY:
 			{
-				time_old = time_now;
 				if(cmd == SL_SPEED || cmd == SL_MUTE || cmd == SL_AUTO ||
 					cmd == SL_TSTAMP || cmd == SL_ACP_CODE || cmd == SL_MASK_REG)
 				{
@@ -566,6 +582,8 @@ char* slcan_parse_str(uint8_t *buf, uint8_t len, twai_message_t *frame, QueueHan
 				{
 					if(cmd == SL_REMOTE_STD || cmd == SL_DATA_STD || cmd == SL_REMOTE_EXT || cmd == SL_DATA_EXT)
 					{
+						esp_err_t tx_err;
+
 						if(loopback)
 						{
 							frame->self = 1;
@@ -575,11 +593,16 @@ char* slcan_parse_str(uint8_t *buf, uint8_t len, twai_message_t *frame, QueueHan
 							frame->self = 0;
 						}
 
-						if (ESP_ERR_INVALID_STATE == can_send(frame, 1))
+						tx_err = can_send(frame, pdMS_TO_TICKS(50));
+						if (tx_err != ESP_OK)
 						{
-							//ESP_LOGE(TAG, "can_send error");
+							ESP_LOGE(TAG, "can_send failed: %s id=0x%lX",
+									 esp_err_to_name(tx_err), (unsigned long)frame->identifier);
 						}
-						ESP_LOGI(TAG, "can_send");
+						else
+						{
+							ESP_LOGI(TAG, "can_send ok id=0x%lX", (unsigned long)frame->identifier);
+						}
 					}
 					cmd_ret = cmd;
 					msg_index = 0;
@@ -621,14 +644,19 @@ char* slcan_parse_str(uint8_t *buf, uint8_t len, twai_message_t *frame, QueueHan
 			}
 		}
 	}
-    // Clear the processed bytes from the buffer
+    // Keep only unconsumed bytes (incomplete trailing command).
     if (i < buffer_index)
     {
         memmove(slcan_buffer, &slcan_buffer[i], buffer_index - i);
         buffer_index -= i;
     }
+    else if (state == SL_HEADER && cmd == SL_NONE)
+    {
+        buffer_index = 0;
+    }
     else
     {
+        /* Mid-command: bytes were absorbed into parser state; drop the raw buffer. */
         buffer_index = 0;
     }
 

--- a/main/slcan.c
+++ b/main/slcan.c
@@ -48,6 +48,7 @@
 static const char serial[] = "N43010123\r";
 static const char version[] = "V2011\r";
 static const char ack[] = "\r";
+static const char nack[] = "\a";
 static const char status[] = "F00\r";
 
 static uint8_t timestamp_flag = 0;
@@ -580,6 +581,7 @@ char* slcan_parse_str(uint8_t *buf, uint8_t len, twai_message_t *frame, QueueHan
 			{
 				if(slcan_buffer[i] == '\r')
 				{
+					uint8_t tx_failed = 0;
 					if(cmd == SL_REMOTE_STD || cmd == SL_DATA_STD || cmd == SL_REMOTE_EXT || cmd == SL_DATA_EXT)
 					{
 						esp_err_t tx_err;
@@ -593,9 +595,10 @@ char* slcan_parse_str(uint8_t *buf, uint8_t len, twai_message_t *frame, QueueHan
 							frame->self = 0;
 						}
 
-						tx_err = can_send(frame, pdMS_TO_TICKS(50));
+						tx_err = can_send(frame, pdMS_TO_TICKS(200));
 						if (tx_err != ESP_OK)
 						{
+							tx_failed = 1;
 							ESP_LOGE(TAG, "can_send failed: %s id=0x%lX",
 									 esp_err_to_name(tx_err), (unsigned long)frame->identifier);
 						}
@@ -633,7 +636,7 @@ char* slcan_parse_str(uint8_t *buf, uint8_t len, twai_message_t *frame, QueueHan
 						}
 						default:
 						{
-							slcan_response((char*)ack, 0, q, NULL);
+							slcan_response(tx_failed ? (char*)nack : (char*)ack, 0, q, NULL);
 							break;
 //							return (char*)ack;
 						}


### PR DESCRIPTION
## Summary

Port of the standard-WiCAN SLCAN TX fix (https://github.com/meatpiHQ/wican-fw/pull/877) onto `wican-pro`. Network SLCAN could ACK host TX commands over TCP while frames never appeared on the CAN bus. Two firmware issues caused this:

1. **TX stall when the host does not drain TCP RX** - if SLCAN ACKs / RX frames piled up unread, `can_tx_task` blocked forever on a full host TX queue / blocking TCP send, so further CAN transmits stopped.
2. **`CAN_ENABLE_BIT` race after SLCAN `O`** - `can_enable()` deferred the enable bit via `can_unblock()` (~10 ms). Immediate `can_send()` after open used a non-blocking bit check and returned `ESP_ERR_INVALID_STATE`, while SLCAN still replied with ACK `\r`. Hosts that transmit right after open (e.g. diagnostic channel setup) therefore got a false success and saw no bus traffic.

Fixes #903

## What changed

### Stall / backpressure (`3cb5ccf`)
- `main/main.c` - host TX queue no longer blocks forever; drop when full
- `main/comm_server.c` - non-blocking TCP send (`MSG_DONTWAIT`); release mutex appropriately
- `main/can.c` - clearer `can_send` / bus-off recovery logging
- `main/slcan.c` - parser idle-gap / buffer hardening; TX frame already zeroed before parse

### Post-open TX reliability (`519e7f0`)
- `main/can.c` - set `CAN_ENABLE_BIT` immediately in `can_enable()` (no 10 ms TX blackout)
- `main/can.c` - `can_send` waits up to 50 ms for the enable bit instead of failing instantly
- `main/slcan.c` - `can_send` timeout increased from 50 ms to 200 ms
- `main/slcan.c` - on TX failure respond with NACK `\a` instead of always ACK `\r`

## Evidence

With a second adapter sniffing the same bus while a network SLCAN client opened a diagnostic channel (setup ID `0x200` / response `0x201`):

| Run | Sniffer saw `0x200` | Sniffer saw `0x201` | Host got setup response | Result |
|-----|---------------------|---------------------|-------------------------|--------|
| Before | No | No | No | Timeout |
| After | Yes | Yes | Yes (~53 ms) | OK |

WiCAN was acknowledging the SLCAN *command* over TCP, but the setup frame was not on the physical CAN bus until these firmware fixes.

## Test plan

- [ ] Flash this build on **WiCAN Pro**
- [ ] Connect via network SLCAN (`socket://` / typical python-can SLCAN client)
- [ ] Open the bus (`O`) and transmit immediately (no long drain delay)
- [ ] Confirm frames appear on the physical bus (optional second adapter / sniffer)
- [ ] Confirm failed TX returns BEL (`\a`) rather than CR ACK when `can_send` fails
- [ ] Regression: idle RX / normal SLCAN traffic still works when the host drains TCP promptly