### PR TITLE
wifi: add optional static STA IP config

### DIFF
--- a/main/config_server.c
+++ b/main/config_server.c
@@ -226,6 +226,26 @@ char *config_server_get_sta_pass(void)
 {
 	return device_config.sta_pass;
 }
+
+char *config_server_get_sta_static_ip(void)
+{
+	return device_config.sta_static_ip;
+}
+
+char *config_server_get_sta_gateway(void)
+{
+	return device_config.sta_gateway;
+}
+
+char *config_server_get_sta_netmask(void)
+{
+	return device_config.sta_netmask;
+}
+
+char *config_server_get_sta_dns(void)
+{
+	return device_config.sta_dns;
+}
 int8_t config_server_protocol(void)
 {
 	if(strcmp(device_config.protocol, "slcan") == 0)
@@ -847,6 +867,10 @@ char *config_server_get_status_json(bool remove_sensitive_info)
 		cJSON_AddStringToObject(root, "sta_pass", device_config.sta_pass);
 		cJSON_AddStringToObject(root, "sta_security", device_config.sta_security);
 		cJSON_AddStringToObject(root, "sta_ip", ip_str);
+		cJSON_AddStringToObject(root, "sta_static_ip", device_config.sta_static_ip);
+		cJSON_AddStringToObject(root, "sta_gateway", device_config.sta_gateway);
+		cJSON_AddStringToObject(root, "sta_netmask", device_config.sta_netmask);
+		cJSON_AddStringToObject(root, "sta_dns", device_config.sta_dns);
 	}
 
 	cJSON_AddStringToObject(root, "sta_status", (wifi_network_is_connected() ? "Connected" : "Not Connected"));
@@ -2035,7 +2059,56 @@ static void config_server_load_cfg(char *cfg)
 	}
 
 	ESP_LOGE(TAG, "device_config.ap_auto_disable: %s", device_config.ap_auto_disable);
-	//*****	
+	//*****
+
+	//***** Optional static STA IP. Any of ip/gateway/netmask missing, empty,
+	// or oversized falls back to "" (DHCP) -- there is no partially-static
+	// state: wifi_network_init only applies it when all three are set.
+	// sta_dns is separately optional -- when static IP is active but DNS is
+	// missing/invalid, wifi_network_init falls back to the gateway.
+	key = cJSON_GetObjectItem(root,"sta_static_ip");
+	if(key == 0 || key->valuestring == NULL || strlen(key->valuestring) >= sizeof(device_config.sta_static_ip))
+	{
+		device_config.sta_static_ip[0] = 0;
+	}
+	else
+	{
+		strcpy(device_config.sta_static_ip, key->valuestring);
+	}
+
+	key = cJSON_GetObjectItem(root,"sta_gateway");
+	if(key == 0 || key->valuestring == NULL || strlen(key->valuestring) >= sizeof(device_config.sta_gateway))
+	{
+		device_config.sta_gateway[0] = 0;
+	}
+	else
+	{
+		strcpy(device_config.sta_gateway, key->valuestring);
+	}
+
+	key = cJSON_GetObjectItem(root,"sta_netmask");
+	if(key == 0 || key->valuestring == NULL || strlen(key->valuestring) >= sizeof(device_config.sta_netmask))
+	{
+		device_config.sta_netmask[0] = 0;
+	}
+	else
+	{
+		strcpy(device_config.sta_netmask, key->valuestring);
+	}
+
+	key = cJSON_GetObjectItem(root,"sta_dns");
+	if(key == 0 || key->valuestring == NULL || strlen(key->valuestring) >= sizeof(device_config.sta_dns))
+	{
+		device_config.sta_dns[0] = 0;
+	}
+	else
+	{
+		strcpy(device_config.sta_dns, key->valuestring);
+	}
+
+	ESP_LOGI(TAG, "device_config.sta_static_ip: %s, gateway: %s, netmask: %s, dns: %s",
+		device_config.sta_static_ip, device_config.sta_gateway, device_config.sta_netmask, device_config.sta_dns);
+	//*****
 
 	//*****
 	key = cJSON_GetObjectItem(root,"keep_alive");

--- a/main/config_server.h
+++ b/main/config_server.h
@@ -68,6 +68,14 @@ typedef struct _device_config
 	char sta_ssid[65];
 	char sta_pass[65];
 	char sta_security[8];
+	// Static STA IP config; each defaults to "" (DHCP) when the key is absent
+	// from config.json, so an incomplete or unset value can never leave the
+	// interface half-configured. sta_dns is optional even when static IP is
+	// in use -- an empty/invalid value falls back to sta_gateway.
+	char sta_static_ip[16];
+	char sta_gateway[16];
+	char sta_netmask[16];
+	char sta_dns[16];
 	char can_datarate[65];
 	char can_mode[65];
 	char port_type[65];
@@ -115,6 +123,10 @@ int8_t config_server_get_ap_ch(void);
 int8_t config_server_get_webhook_en(void);
 char *config_server_get_sta_ssid(void);
 char *config_server_get_sta_pass(void);
+char *config_server_get_sta_static_ip(void);
+char *config_server_get_sta_gateway(void);
+char *config_server_get_sta_netmask(void);
+char *config_server_get_sta_dns(void);
 int8_t config_server_get_can_rate(void);
 int8_t config_server_get_can_mode(void);
 int8_t config_server_get_port_type(void);

--- a/main/homepage_full.html
+++ b/main/homepage_full.html
@@ -636,6 +636,39 @@
                             </select>
                         </td>
                     </tr>
+                    <tr>
+                        <td>IP Config:</td>
+                        <td>
+                            <select id="sta_ip_mode" name="sta_ip_mode" disabled onchange="sta_ip_mode_toggle(); submit_enable();">
+                                <option value="dhcp">DHCP</option>
+                                <option value="static">Static</option>
+                            </select>
+                        </td>
+                    </tr>
+                    <tr class="sta_static_row">
+                        <td>IP Address:</td>
+                        <td>
+                            <input type="text" id="sta_static_ip" name="sta_static_ip" placeholder="192.168.1.50" disabled />
+                        </td>
+                    </tr>
+                    <tr class="sta_static_row">
+                        <td>Netmask:</td>
+                        <td>
+                            <input type="text" id="sta_netmask" name="sta_netmask" placeholder="255.255.255.0" disabled />
+                        </td>
+                    </tr>
+                    <tr class="sta_static_row">
+                        <td>Gateway:</td>
+                        <td>
+                            <input type="text" id="sta_gateway" name="sta_gateway" placeholder="192.168.1.1" disabled />
+                        </td>
+                    </tr>
+                    <tr class="sta_static_row">
+                        <td>DNS (optional):</td>
+                        <td>
+                            <input type="text" id="sta_dns" name="sta_dns" placeholder="192.168.1.1" disabled />
+                        </td>
+                    </tr>
                 </table>
 
                 <div class="divider"></div>
@@ -2279,21 +2312,50 @@ function loadAutoTable(jsonData) {
 
 	function sta_enable() {}
 
+	function is_ipv4(s) {
+		if(typeof s != "string") return false;
+		var parts = s.split(".");
+		if(parts.length != 4) return false;
+		for(var i = 0; i < 4; i++) {
+			if(!/^\d{1,3}$/.test(parts[i])) return false;
+			if(parts[i].length > 1 && parts[i][0] == "0") return false;
+			var n = parseInt(parts[i], 10);
+			if(n < 0 || n > 255) return false;
+		}
+		return true;
+	}
+
+	function sta_ip_mode_toggle() {
+		var isStatic = document.getElementById("sta_ip_mode").value == "static";
+		var staDisabled = document.getElementById("sta_ip_mode").disabled;
+		var rows = document.getElementsByClassName("sta_static_row");
+		for(var i = 0; i < rows.length; i++) {
+			rows[i].style.display = isStatic ? "" : "none";
+			var input = rows[i].querySelector("input");
+			if(input) {
+				input.disabled = staDisabled || !isStatic;
+			}
+		}
+	}
+
 	function submit_enable() {
         console.log("sumbit_enable");
 		if(document.getElementById("wifi_mode").value == "AP") {
 			document.getElementById("ssid_value").disabled = true;
 			document.getElementById("pass_value").disabled = true;
             document.getElementById("sta_security").disabled = true;
+            document.getElementById("sta_ip_mode").disabled = true;
 			document.getElementById("ble_status").disabled = false;
             document.getElementById("ap_auto_disable").disabled = true;
 		} else {
 			document.getElementById("ssid_value").disabled = false;
 			document.getElementById("pass_value").disabled = false;
             document.getElementById("sta_security").disabled = false;
+            document.getElementById("sta_ip_mode").disabled = false;
 			document.getElementById("ble_status").disabled = true;
 			document.getElementById("ble_status").selectedIndex = "1";
 		}
+        sta_ip_mode_toggle();
 		if(document.getElementById("ble_status").selectedIndex == "0") {
 			document.getElementById("ble_warning_div").style.display = "block";
 			document.getElementById("mqtt_en").value = "disable";
@@ -2336,6 +2398,13 @@ function loadAutoTable(jsonData) {
 			document.getElementById("submit_button").disabled = true;
 		} else if(document.getElementById("batt_alert_volt").value < 8 || document.getElementById("batt_alert_volt").value > 15) {
             showNotification("Alert Voltage Value, min=8.0 max=15.0", "red");
+			document.getElementById("submit_button").disabled = true;
+		} else if(document.getElementById("wifi_mode").value != "AP" && document.getElementById("sta_ip_mode").value == "static" &&
+                (!is_ipv4(document.getElementById("sta_static_ip").value) ||
+                 !is_ipv4(document.getElementById("sta_netmask").value) ||
+                 !is_ipv4(document.getElementById("sta_gateway").value) ||
+                 (document.getElementById("sta_dns").value.length > 0 && !is_ipv4(document.getElementById("sta_dns").value)))) {
+            showNotification("Static IP/netmask/gateway must be valid IPv4", "red");
 			document.getElementById("submit_button").disabled = true;
 		}
         else {
@@ -2661,6 +2730,17 @@ function loadAutoTable(jsonData) {
 		obj["sta_ssid"] = document.getElementById("ssid_value").value;
 		obj["sta_pass"] = document.getElementById("pass_value").value;
         obj["sta_security"] = document.getElementById("sta_security").value;
+        if(document.getElementById("sta_ip_mode").value == "static") {
+            obj["sta_static_ip"] = document.getElementById("sta_static_ip").value;
+            obj["sta_netmask"] = document.getElementById("sta_netmask").value;
+            obj["sta_gateway"] = document.getElementById("sta_gateway").value;
+            obj["sta_dns"] = document.getElementById("sta_dns").value;
+        } else {
+            obj["sta_static_ip"] = "";
+            obj["sta_netmask"] = "";
+            obj["sta_gateway"] = "";
+            obj["sta_dns"] = "";
+        }
 		obj["can_datarate"] = document.getElementById("can_datarate").value;
 		obj["can_mode"] = document.getElementById("can_mode").value;
 		obj["port_type"] = document.getElementById("port_type").value;
@@ -2894,11 +2974,13 @@ function loadAutoTable(jsonData) {
 				document.getElementById("ssid_value").disabled = false;
 				document.getElementById("pass_value").disabled = false;
                 document.getElementById("sta_security").disabled = false;
+                document.getElementById("sta_ip_mode").disabled = false;
                 document.getElementById("ap_auto_disable").disabled = false;
 			} else if(obj.wifi_mode == "AP") {
 				document.getElementById("wifi_mode").selectedIndex = "0";
 				document.getElementById("ssid_value").disabled = true;
 				document.getElementById("pass_value").disabled = true;
+                document.getElementById("sta_ip_mode").disabled = true;
                 document.getElementById("ap_auto_disable").disabled = true;
 			}
 
@@ -2913,8 +2995,16 @@ function loadAutoTable(jsonData) {
 			document.getElementById("ap_ch_value").selectedIndex = ch.toString();
 			document.getElementById("ssid_value").value = obj.sta_ssid;
 			document.getElementById("pass_value").value = obj.sta_pass;
-            document.getElementById("sta_security").value = obj.sta_security || "wpa3";	
-            
+            document.getElementById("sta_security").value = obj.sta_security || "wpa3";
+
+            document.getElementById("sta_static_ip").value = obj.sta_static_ip || "";
+            document.getElementById("sta_netmask").value = obj.sta_netmask || "";
+            document.getElementById("sta_gateway").value = obj.sta_gateway || "";
+            document.getElementById("sta_dns").value = obj.sta_dns || "";
+            document.getElementById("sta_ip_mode").value =
+                (obj.sta_static_ip && obj.sta_gateway && obj.sta_netmask) ? "static" : "dhcp";
+            sta_ip_mode_toggle();
+
             const webhookEnEl = document.getElementById("webhook_en");
             if (webhookEnEl) {
                 const webhookModeFromCfg = obj.webhook_en || "enable";

--- a/main/wifi_network.c
+++ b/main/wifi_network.c
@@ -34,6 +34,7 @@
  #include "config_server.h"
  #include "ble.h"
  #include "dev_status.h"
+ #include "lwip/ip4_addr.h"
  
  #define WIFI_CONNECTED_BIT 			BIT0
  #define WIFI_FAIL_BIT     			BIT1
@@ -357,6 +358,52 @@
          }
          ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_APSTA));
          ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config_sta) );
+
+         // Optional static STA IP. Only applied when all three fields are
+         // set and parse cleanly -- any missing/invalid field leaves DHCP
+         // running, so a bad config can never leave the interface addressless.
+         char *sta_static_ip = config_server_get_sta_static_ip();
+         char *sta_gateway = config_server_get_sta_gateway();
+         char *sta_netmask = config_server_get_sta_netmask();
+         if(strlen(sta_static_ip) > 0 && strlen(sta_gateway) > 0 && strlen(sta_netmask) > 0)
+         {
+             esp_netif_ip_info_t sta_ip_info;
+             memset(&sta_ip_info, 0, sizeof(sta_ip_info));
+             if(ip4addr_aton(sta_static_ip, (ip4_addr_t*)&sta_ip_info.ip) &&
+                ip4addr_aton(sta_gateway, (ip4_addr_t*)&sta_ip_info.gw) &&
+                ip4addr_aton(sta_netmask, (ip4_addr_t*)&sta_ip_info.netmask))
+             {
+                 esp_netif_dhcpc_stop(sta_netif);
+                 esp_netif_set_ip_info(sta_netif, &sta_ip_info);
+
+                 // Stopping the DHCP client also drops the DNS servers it was
+                 // handed, so hostname-based MQTT/webhook targets would stop
+                 // resolving unless we set one here. sta_dns is optional --
+                 // fall back to the gateway, which resolves on virtually
+                 // every home router.
+                 char *sta_dns = config_server_get_sta_dns();
+                 ip4_addr_t dns_addr;
+                 int have_dns = (strlen(sta_dns) > 0) && ip4addr_aton(sta_dns, &dns_addr);
+                 if(!have_dns)
+                 {
+                     dns_addr = *(ip4_addr_t*)&sta_ip_info.gw;
+                 }
+                 esp_netif_dns_info_t sta_dns_info;
+                 memset(&sta_dns_info, 0, sizeof(sta_dns_info));
+                 sta_dns_info.ip.type = ESP_IPADDR_TYPE_V4;
+                 sta_dns_info.ip.u_addr.ip4.addr = dns_addr.addr;
+                 esp_netif_set_dns_info(sta_netif, ESP_NETIF_DNS_MAIN, &sta_dns_info);
+
+                 ESP_LOGI(WIFI_TAG, "Static STA IP: %s gw: %s mask: %s dns: %s",
+                         sta_static_ip, sta_gateway, sta_netmask,
+                         have_dns ? sta_dns : sta_gateway);
+             }
+             else
+             {
+                 ESP_LOGE(WIFI_TAG, "Invalid static STA IP config, falling back to DHCP");
+             }
+         }
+
          if(xwifi_handle == NULL)
          {
              xTaskCreate(wifi_conn_task, "wifi_conn_task", 4096, (void*)AF_INET, 5, &xwifi_handle);


### PR DESCRIPTION
A DHCP reservation on the router still runs the full DHCP transaction (Discover/Offer/Request/Ack) on every reconnect. A device-side static IP skips it entirely, shaving time off the arrival-to-first-webhook- post window on a vehicle install that reconnects from cold on every trip.

Adds four optional config.json fields (sta_static_ip, sta_gateway, sta_netmask, sta_dns), each defaulting to "" (DHCP, current behavior) when absent. wifi_network_init() only calls esp_netif_dhcpc_stop() + esp_netif_set_ip_info() when ip/gateway/netmask are all present and parse as valid IPv4 addresses -- an incomplete or malformed config always falls back to DHCP rather than leaving the interface addressless.

Stopping the DHCP client also drops the DNS servers it handed out, which would silently break a hostname-based MQTT broker or HA webhook URL. sta_dns is separately optional: when static IP is active and sta_dns is empty or doesn't parse, the gateway is used as the DNS server, which resolves on virtually every home router.

The web UI's Station Config section gets a DHCP/Static dropdown that reveals IP/Netmask/Gateway/DNS fields when Static is selected. DHCP/Static is derived from whether the address fields are populated rather than stored as its own key, so config.json keeps a single source of truth. postConfig() now always sends the four keys (blank in DHCP mode), so saving any other setting from the web UI no longer silently drops a configured static IP back to DHCP.