### PR TITLE
Raise HV_V and HV_KWH_R bounds for 800V/84kWh packs

### DIFF
--- a/.vehicle_profiles/params.json
+++ b/.vehicle_profiles/params.json
@@ -2119,7 +2119,7 @@
       "unit": "Wh",
       "class": "energy",
       "min": "0",
-      "max": "77000"
+      "max": "120000"
     }
   },
   "HV_RELAY": {
@@ -2471,7 +2471,7 @@
       "unit": "V",
       "class": "voltage",
       "min": "200",
-      "max": "480"
+      "max": "900"
     }
   },
   "HV_W": {


### PR DESCRIPTION
autopid silently drops any reading outside min/max (main/autopid.c:1699). HV_V max of 480 filtered out every reading on 800V e-GMP cars, so HV_V currently produces nothing on the existing Ioniq5/6 and EV6 profiles. HV_KWH_R max of 77000 clips packs larger than 77kWh.