### PR TITLE
Add Hyundai Ioniq 5 N 84kWh profile; fix extends merge dropping re-declared PID params

### DIFF
--- a/.vehicle_profiles/src/cars.js
+++ b/.vehicle_profiles/src/cars.js
@@ -94,7 +94,8 @@ async function add_json(jsonPath, params, allCars) {
     });
     newCar.pids.forEach((pid) => {
       if (Object.keys(pidtokey).includes(pid.pid)) {
-        pid.parameters = { ...pid.parameters, ...car.parameters };
+        const existing = car.pids[pidtokey[pid.pid]];
+        existing.parameters = { ...existing.parameters, ...pid.parameters };
       } else {
         car.pids.push(pid);
       }

--- a/vehicle_profiles/hyundai/ioniq5n_84kWh.json
+++ b/vehicle_profiles/hyundai/ioniq5n_84kWh.json
@@ -1,0 +1,6 @@
+{
+  "car_model": "Hyundai: Ioniq 5 N 84kWh (2025)",
+  "init": "ATSH7E4;ATST96;",
+  "extends": "hyundai/ioniq5-6_77kWh.json",
+  "note": "Same E-GMP BMS layout as the Ioniq 5/6 77kWh (192 cells). Byte map cross-checked against an independent 2025 Ioniq 5 N decode (timurrrr/hyundai-n)."
+}


### PR DESCRIPTION
## What

1. **New profile** `vehicle_profiles/hyundai/ioniq5n_84kWh.json`: "Hyundai: Ioniq 5 N 84kWh (2025)". The N uses the same E-GMP BMS layout as the Ioniq 5/6 77 kWh pack (2P192S), so this is a thin `extends` of `hyundai/ioniq5-6_77kWh.json` under a name N owners will find in the dropdown. The byte map matches an independent 2025 Ioniq 5 N decode published in [timurrrr/hyundai-n](https://github.com/timurrrr/hyundai-n/blob/main/IONIQ_5_N/data_logging.md) (pack current, voltage and temperatures line up with a constant offset between the two tools' byte-counting conventions).

2. **Build fix** in `.vehicle_profiles/src/cars.js`: when an extending profile re-declares a PID that already exists in the base, the merge assigned `{...pid.parameters, ...car.parameters}` (where `car.parameters` is undefined) to the *new* pid object and then never added it to `car.pids`, so those parameters were silently dropped. The existing 77 kWh profile is affected: its `22010C` cells 181-192 are missing from the generated `vehicle_profiles.json` today (the generated entry is byte-identical to the 72 kWh one). The fix merges the new parameters into the existing PID entry.

## Verification

`npm run validate` and `npm run build` pass. Generated result:

| profile | params | cells |
|---|---|---|
| Ioniq5/Ioniq6 72kWh | 246 | 001..180 (unchanged) |
| Ioniq5/Ioniq6 77kWh (2021-2024) | 258 | 001..192 (was 180) |
| Ioniq 5 N 84kWh (2025) | 258 | 001..192 |

No other profile's output changes.

## Status

Opened as a **draft** pending a live run on a 2025 Ioniq 5 N (WiCAN-OBD, fw 4.21). I'll mark it ready once SOC, LV_V and the cell voltages have been confirmed against the car; happy to split the merge fix into its own PR if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
