### PR TITLE
Fix race leading to double-free panic in autopid.c

### DIFF
--- a/components/autopid/autopid.c
+++ b/components/autopid/autopid.c
@@ -693,7 +693,7 @@ static void autopid_data_update(autopid_config_t *pids)
 char *autopid_data_read(void)
 {
     // json_str must be freed by the caller
-    static char *json_str = NULL;
+    char *json_str = NULL;
 
     if (!autopid_data.mutex)
     {


### PR DESCRIPTION
autopid_data_read() uses a "static" variable json_str, which can be shared between concurrent calls to autopid_data_read from either obd-logger or autopid_task.

When first caller (like obd-log) release the semaphore, if it is descheduled to run second caller, then json_str will be globally overwritten and the "return json_str" statement can end-up returning the same buffer value twice, it will be free twice, leading to panic and sometimes corrupting the sqlite3 file.

Switching to local variable fixes the issue.

Fixes #941 