### PR TITLE
autopid: release the mutex when autopid_get_config() cannot allocate

### DIFF
--- a/main/autopid.c
+++ b/main/autopid.c
@@ -1049,6 +1049,9 @@ char* autopid_get_config(void)
     {
         ESP_LOGE(TAG, "Failed to create JSON object");
         DEBUG_LOGE(TAG, "Failed to create JSON object");
+        // The mutex is held from here on; returning without giving it back
+        // leaves every other autopid consumer blocked forever.
+        xSemaphoreGive(all_pids->mutex);
         return NULL;
     }
 


### PR DESCRIPTION
autopid_get_config() takes all_pids->mutex with portMAX_DELAY, then returns NULL on the cJSON_CreateObject() failure path without giving it back. Every other consumer of all_pids blocks on that mutex forever, which stops the polling task dead - a failure mode considerably worse than the allocation failure that triggered it.

The path only opens under memory pressure, but it is reachable from the HTTP handler for /autopid_config, so anything that can reach the web UI can retry it.