### PR TITLE
autopid: send per-parameter unit and class in the webhook config

### DIFF
--- a/main/autopid.c
+++ b/main/autopid.c
@@ -2281,6 +2281,7 @@ static void autopid_webhook_task(void *pvParameters)
     char *prev_autopid_snapshot = NULL;
     char *prev_config_snapshot = NULL;
     char *prev_status_snapshot = NULL;
+    bool param_meta_posted = false;
 
     vTaskDelay(pdMS_TO_TICKS(5000));
 
@@ -2352,6 +2353,7 @@ static void autopid_webhook_task(void *pvParameters)
                 {
                     last_post_time = now;
 
+                    bool param_meta_pending = false;
                     char *raw_json = autopid_data_read();
                     if (raw_json)
                     {
@@ -2446,6 +2448,43 @@ static void autopid_webhook_task(void *pvParameters)
                                     }
                                 }
 
+                                // Per-parameter unit/class metadata. Consumers such as
+                                // ha-wican look for config[<PARAM>]["unit"], but the
+                                // config object otherwise carries only device-level
+                                // settings, so they silently fall back to their own
+                                // bundled copy of params.json and a profile that
+                                // publishes a different unit is overridden.
+                                //
+                                // Sent once per boot rather than on every post: it is a
+                                // few KB, it does not change while the device is up, and
+                                // json_object_diff_simple() only diffs scalars, so a diff
+                                // payload would never carry it at all.
+                                if (!param_meta_posted && cfg_payload)
+                                {
+                                    char *param_json = autopid_get_config();
+                                    if (param_json)
+                                    {
+                                        cJSON *params_obj = cJSON_Parse(param_json);
+                                        if (params_obj)
+                                        {
+                                            cJSON *it = NULL;
+                                            cJSON_ArrayForEach(it, params_obj)
+                                            {
+                                                if (!it->string)
+                                                    continue;
+                                                cJSON *copy = cJSON_Duplicate(it, true);
+                                                if (!copy)
+                                                    continue;
+                                                cJSON_DeleteItemFromObjectCaseSensitive(cfg_payload, it->string);
+                                                cJSON_AddItemToObject(cfg_payload, it->string, copy);
+                                            }
+                                            cJSON_Delete(params_obj);
+                                            param_meta_pending = true;
+                                        }
+                                        free(param_json);
+                                    }
+                                }
+
                                 if (cfg_payload && cJSON_GetArraySize(cfg_payload) > 0)
                                     cJSON_AddItemToObject(root_obj, "config", cfg_payload);
                                 else if (cfg_payload)
@@ -2487,6 +2526,8 @@ static void autopid_webhook_task(void *pvParameters)
                                     ha_webhook_config_t upd = webhook_cfg;
                                     if (ok)
                                     {
+                                        if (param_meta_pending)
+                                            param_meta_posted = true;
                                         upd.success_count++;
                                         upd.retries = 0;
                                         strlcpy(upd.status, "ok", sizeof(upd.status));


### PR DESCRIPTION
The webhook's config object carries only device-level settings - cycle, grouping, webhook_data_mode, car_model, ha_discovery, autopid_polling. Consumers look for per-parameter metadata in the same object: the Home Assistant integration resolves a sensor's unit as "device config first, params.json second" and reads config[<PARAM>]["unit"], which is never present, so the fallback is the only path that ever runs.

The effect is that a profile publishing a unit that differs from the one upstream params.json records for that name is silently overridden. The VW e-Golf reports its remaining range in whatever unit the dash is set to, so the profile ships RANGE as "mi" for a US car; params.json says "km" and Home Assistant converts a 95 mile range into 59.

autopid_get_config() already builds exactly the {NAME: {class, unit}} object these consumers expect - it backs the /autopid_config endpoint. Merge it into the config payload once per boot, after which the consumer has stored it. Once per boot rather than every post because it is a few KB that cannot change while the device is up, and because json_object_diff_simple() only diffs scalars, so a diff-mode payload would otherwise never carry it at all. The flag is only cleared when the POST carrying it was accepted, so a failed first post retries.