### PR TITLE
main: drop the duplicate and empty SRCS entries

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -3,7 +3,7 @@
 set(srcs "main.c" "comm_server.c" "config_server.c" "realdash.c" "slcan.c" "can.c" "ble.c" "wifi_network.c" "gvret.c" "wc_uart.c" "elm327.c" "mqtt.c" "sleep_mode.c" "autopid.c" "expression_parser.c" "wc_mdns.c" "wc_timer.c" "dev_status.c")
 set(requires   esp_timer esp_wifi nvs_flash fatfs vfs driver esp-tls esp_adc esp_eth log app_update esp_http_server bt spiffs freertos mqtt json debug_logs ha_webhooks filesystem)
 idf_component_register(
-    SRCS "hw_config.c" "wc_timer.c" "autopid.c" "ftp.c" "" "${srcs}"        # list the source files of this component
+    SRCS "hw_config.c" "ftp.c" "${srcs}"        # list the source files of this component
     INCLUDE_DIRS "."    # optional, add here public include directories
     PRIV_INCLUDE_DIRS   # optional, add here private include directories
     REQUIRES   "${requires}"         # optional, list the public requirements (component names)


### PR DESCRIPTION
idf_component_register() listed wc_timer.c and autopid.c explicitly as well as via ${srcs}, and carried a stray "" between ftp.c and ${srcs}.

The empty string is the one that matters: CMake resolves it against the component directory, so the source list contains a bare path to main/ itself. It has not broken a build so far, but it is a directory sitting in a list of translation units.

All 20 sources are still listed, each exactly once, and each exists.